### PR TITLE
added unit tests for athena-datalakegen2

### DIFF
--- a/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2EnvironmentPropertiesTest.java
+++ b/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2EnvironmentPropertiesTest.java
@@ -1,0 +1,84 @@
+/*-
+ * #%L
+ * athena-datalakegen2
+ * %%
+ * Copyright (C) 2019 - 2025 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.datalakegen2;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.DATABASE;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.DEFAULT;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.HOST;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.PORT;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.SECRET_NAME;
+import static org.junit.Assert.assertEquals;
+
+public class DataLakeGen2EnvironmentPropertiesTest
+{
+    private Map<String, String> connectionProperties;
+    private DataLakeGen2EnvironmentProperties dataLakeGen2EnvironmentProperties;
+
+    @Before
+    public void setUp()
+    {
+        connectionProperties = new HashMap<>();
+        connectionProperties.put(HOST, "afq-connection-000.sql.azuressss.net");
+        connectionProperties.put(PORT, "1433");
+        connectionProperties.put(DATABASE, "testDB");
+        connectionProperties.put(SECRET_NAME, "secret");
+
+        dataLakeGen2EnvironmentProperties = new DataLakeGen2EnvironmentProperties();
+    }
+
+    @Test
+    public void connectionPropertiesToEnvironment_WithValidProperties_ReturnsExpectedConnectionString()
+    {
+        Map<String, String> dataLakeGen2ConnectionProperties = dataLakeGen2EnvironmentProperties.connectionPropertiesToEnvironment(connectionProperties);
+
+        String expectedConnectionString = "datalakegentwo://jdbc:sqlserver://afq-connection-000.sql.azuressss.net:1433;databaseName=testDB;${secret}";
+        assertEquals(expectedConnectionString, dataLakeGen2ConnectionProperties.get(DEFAULT));
+    }
+
+    @Test
+    public void getDelimiter_ReturnsSemicolonDelimiter()
+    {
+        assertEquals(";", dataLakeGen2EnvironmentProperties.getDelimiter());
+    }
+
+    @Test
+    public void getConnectionStringPrefix_WithValidProperties_ReturnsPrefix()
+    {
+        assertEquals("datalakegentwo://jdbc:sqlserver://", dataLakeGen2EnvironmentProperties.getConnectionStringPrefix(connectionProperties));
+    }
+
+    @Test
+    public void getJdbcParametersSeparator_ReturnsSemicolonSeparator()
+    {
+        assertEquals(";", dataLakeGen2EnvironmentProperties.getJdbcParametersSeparator());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void connectionPropertiesToEnvironment_WithNullProperties_ThrowsNullPointerException()
+    {
+        dataLakeGen2EnvironmentProperties.connectionPropertiesToEnvironment(null);
+    }
+}

--- a/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2EnvironmentPropertiesTest.java
+++ b/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2EnvironmentPropertiesTest.java
@@ -41,7 +41,7 @@ public class DataLakeGen2EnvironmentPropertiesTest
     public void setUp()
     {
         connectionProperties = new HashMap<>();
-        connectionProperties.put(HOST, "afq-connection-000.sql.azuressss.net");
+        connectionProperties.put(HOST, "afq-connection-000.sql.azure.net");
         connectionProperties.put(PORT, "1433");
         connectionProperties.put(DATABASE, "testDB");
         connectionProperties.put(SECRET_NAME, "secret");
@@ -54,12 +54,12 @@ public class DataLakeGen2EnvironmentPropertiesTest
     {
         Map<String, String> dataLakeGen2ConnectionProperties = dataLakeGen2EnvironmentProperties.connectionPropertiesToEnvironment(connectionProperties);
 
-        String expectedConnectionString = "datalakegentwo://jdbc:sqlserver://afq-connection-000.sql.azuressss.net:1433;databaseName=testDB;${secret}";
+        String expectedConnectionString = "datalakegentwo://jdbc:sqlserver://afq-connection-000.sql.azure.net:1433;databaseName=testDB;${secret}";
         assertEquals(expectedConnectionString, dataLakeGen2ConnectionProperties.get(DEFAULT));
     }
 
     @Test
-    public void getDelimiter_ReturnsSemicolonDelimiter()
+    public void getDelimiter_WithDefaultConfiguration_ReturnsSemicolonDelimiter()
     {
         assertEquals(";", dataLakeGen2EnvironmentProperties.getDelimiter());
     }
@@ -71,7 +71,7 @@ public class DataLakeGen2EnvironmentPropertiesTest
     }
 
     @Test
-    public void getJdbcParametersSeparator_ReturnsSemicolonSeparator()
+    public void getJdbcParametersSeparator_WithDefaultConfiguration_ReturnsSemicolonSeparator()
     {
         assertEquals(";", dataLakeGen2EnvironmentProperties.getJdbcParametersSeparator());
     }
@@ -80,5 +80,44 @@ public class DataLakeGen2EnvironmentPropertiesTest
     public void connectionPropertiesToEnvironment_WithNullProperties_ThrowsNullPointerException()
     {
         dataLakeGen2EnvironmentProperties.connectionPropertiesToEnvironment(null);
+    }
+
+    @Test
+    public void connectionPropertiesToEnvironment_WithEmptyProperties_ReturnsConnectionStringWithNulls()
+    {
+        Map<String, String> sqlServerConnectionProperties = dataLakeGen2EnvironmentProperties.connectionPropertiesToEnvironment(new HashMap<>());
+
+        String expectedConnectionString = "datalakegentwo://jdbc:sqlserver://null:null;databaseName=null;";
+        assertEquals(expectedConnectionString, sqlServerConnectionProperties.get(DEFAULT));
+    }
+
+    @Test
+    public void connectionPropertiesToEnvironment_WithMissingHost_ReturnsConnectionStringWithNullHost()
+    {
+        connectionProperties.remove(HOST);
+        Map<String, String> sqlServerConnectionProperties = dataLakeGen2EnvironmentProperties.connectionPropertiesToEnvironment(connectionProperties);
+
+        String expectedConnectionString = "datalakegentwo://jdbc:sqlserver://null:1433;databaseName=testDB;${secret}";
+        assertEquals(expectedConnectionString, sqlServerConnectionProperties.get(DEFAULT));
+    }
+
+    @Test
+    public void connectionPropertiesToEnvironment_WithMissingPort_ReturnsConnectionStringWithNullPort()
+    {
+        connectionProperties.remove(PORT);
+        Map<String, String> sqlServerConnectionProperties = dataLakeGen2EnvironmentProperties.connectionPropertiesToEnvironment(connectionProperties);
+
+        String expectedConnectionString = "datalakegentwo://jdbc:sqlserver://afq-connection-000.sql.azure.net:null;databaseName=testDB;${secret}";
+        assertEquals(expectedConnectionString, sqlServerConnectionProperties.get(DEFAULT));
+    }
+
+    @Test
+    public void connectionPropertiesToEnvironment_WithMissingDatabase_ReturnsConnectionStringWithNullDatabase()
+    {
+        connectionProperties.remove(DATABASE);
+        Map<String, String> sqlServerConnectionProperties = dataLakeGen2EnvironmentProperties.connectionPropertiesToEnvironment(connectionProperties);
+
+        String expectedConnectionString = "datalakegentwo://jdbc:sqlserver://afq-connection-000.sql.azure.net:1433;databaseName=null;${secret}";
+        assertEquals(expectedConnectionString, sqlServerConnectionProperties.get(DEFAULT));
     }
 }

--- a/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MetadataHandlerTest.java
+++ b/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MetadataHandlerTest.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.datalakegen2;
 
 import com.amazonaws.athena.connector.credentials.CredentialsProvider;
+import com.amazonaws.athena.connector.lambda.data.Block;
 import com.amazonaws.athena.connector.lambda.data.BlockAllocator;
 import com.amazonaws.athena.connector.lambda.data.BlockAllocatorImpl;
 import com.amazonaws.athena.connector.lambda.data.BlockUtils;
@@ -28,6 +29,8 @@ import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
+import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesRequest;
+import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetSplitsRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetSplitsResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableLayoutRequest;
@@ -36,12 +39,14 @@ import com.amazonaws.athena.connector.lambda.metadata.GetTableRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableResponse;
 import com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest;
 import com.amazonaws.athena.connector.lambda.metadata.ListTablesResponse;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.OptimizationSubType;
 import com.amazonaws.athena.connector.lambda.security.FederatedIdentity;
 import com.amazonaws.athena.connectors.datalakegen2.resolver.DataLakeGen2CaseResolver;
 import com.amazonaws.athena.connectors.jdbc.TestBase;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
 import com.amazonaws.athena.connectors.jdbc.connection.JdbcConnectionFactory;
 import com.amazonaws.athena.connectors.jdbc.manager.JDBCUtil;
+import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.Before;
@@ -56,13 +61,17 @@ import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRespon
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -71,6 +80,7 @@ import static com.amazonaws.athena.connectors.datalakegen2.DataLakeGen2MetadataH
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
@@ -110,7 +120,7 @@ public class DataLakeGen2MetadataHandlerTest
     }
 
     @Test
-    public void getPartitionSchema()
+    public void getPartitionSchema_WithName_ReturnsSchema()
     {
         assertEquals(SchemaBuilder.newBuilder()
                         .addField(PARTITION_NUMBER, org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType()).build(),
@@ -118,11 +128,18 @@ public class DataLakeGen2MetadataHandlerTest
     }
 
     @Test
-    public void doGetTableLayoutWithNoPartitions()
+    public void doGetTableLayout_NoPartitions_ReturnsSinglePartition()
             throws Exception
     {
         BlockAllocator blockAllocator = new BlockAllocatorImpl();
-        Constraints constraints = mock(Constraints.class);
+        Constraints constraints = new Constraints(
+                Collections.emptyMap(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Constraints.DEFAULT_NO_LIMIT,
+                Collections.emptyMap(),
+                null
+        );
         TableName tableName = new TableName("testSchema", "testTable");
 
         Schema partitionSchema = this.dataLakeGen2MetadataHandler.getPartitionSchema("testCatalogName");
@@ -146,10 +163,17 @@ public class DataLakeGen2MetadataHandlerTest
     }
 
     @Test(expected = RuntimeException.class)
-    public void doGetTableLayoutWithSQLException()
+    public void doGetTableLayout_WithSQLException_ThrowsRuntimeException()
             throws Exception
     {
-        Constraints constraints = mock(Constraints.class);
+        Constraints constraints = new Constraints(
+                Collections.emptyMap(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Constraints.DEFAULT_NO_LIMIT,
+                Collections.emptyMap(),
+                null
+        );
         TableName tableName = new TableName("testSchema", "testTable");
         Schema partitionSchema = this.dataLakeGen2MetadataHandler.getPartitionSchema("testCatalogName");
         Set<String> partitionCols = partitionSchema.getFields().stream().map(Field::getName).collect(Collectors.toSet());
@@ -165,11 +189,18 @@ public class DataLakeGen2MetadataHandlerTest
     }
 
     @Test
-    public void doGetSplitsWithNoPartition()
+    public void doGetSplits_NoPartition_ReturnsSingleSplit()
             throws Exception
     {
         BlockAllocator blockAllocator = new BlockAllocatorImpl();
-        Constraints constraints = mock(Constraints.class);
+        Constraints constraints = new Constraints(
+                Collections.emptyMap(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Constraints.DEFAULT_NO_LIMIT,
+                Collections.emptyMap(),
+                null
+        );
         TableName tableName = new TableName("testSchema", "testTable");
 
         Schema partitionSchema = this.dataLakeGen2MetadataHandler.getPartitionSchema("testCatalogName");
@@ -235,7 +266,7 @@ public class DataLakeGen2MetadataHandlerTest
     }
 
     @Test
-    public void testGetSchemaWithAzureServerlessEnvironment()
+    public void doGetTable_AzureServerlessEnvironment()
             throws Exception
     {
         BlockAllocator blockAllocator = new BlockAllocatorImpl();
@@ -357,7 +388,7 @@ public class DataLakeGen2MetadataHandlerTest
     }
 
     @Test
-    public void testGetSchemaWithStandardEnvironment()
+    public void doGetTable_StandardEnvironment()
             throws Exception
     {
         BlockAllocator blockAllocator = new BlockAllocatorImpl();
@@ -427,5 +458,160 @@ public class DataLakeGen2MetadataHandlerTest
         };
 
         assertEquals(Arrays.toString(expectedTables), listTablesResponse.getTables().toString());
+    }
+
+    @Test
+    public void doGetDataSourceCapabilities_ReturnsCapabilities()
+    {
+        BlockAllocator allocator = new BlockAllocatorImpl();
+        GetDataSourceCapabilitiesRequest request =
+                new GetDataSourceCapabilitiesRequest(federatedIdentity, "testQueryId", "testCatalog");
+
+        GetDataSourceCapabilitiesResponse response =
+                dataLakeGen2MetadataHandler.doGetDataSourceCapabilities(allocator, request);
+
+        Map<String, List<OptimizationSubType>> capabilities = response.getCapabilities();
+
+        assertEquals("testCatalog", response.getCatalogName());
+
+        // Verify filter pushdown capabilities
+        List<OptimizationSubType> filterPushdown = capabilities.get("supports_filter_pushdown");
+        assertNotNull("Expected supports_filter_pushdown capability to be present", filterPushdown);
+        assertEquals(2, filterPushdown.size());
+        assertTrue(filterPushdown.stream().anyMatch(subType -> subType.getSubType().equals("sorted_range_set")));
+        assertTrue(filterPushdown.stream().anyMatch(subType -> subType.getSubType().equals("nullable_comparison")));
+
+        // Verify complex expression pushdown capabilities
+        List<OptimizationSubType> complexPushdown = capabilities.get("supports_complex_expression_pushdown");
+        assertNotNull("Expected supports_complex_expression_pushdown capability to be present", complexPushdown);
+        assertEquals(1, complexPushdown.size());
+        OptimizationSubType complexSubType = complexPushdown.get(0);
+        assertEquals("supported_function_expression_types", complexSubType.getSubType());
+        assertNotNull("Expected function expression types to be present", complexSubType.getProperties());
+        assertFalse("Expected function expression types to be non-empty", complexSubType.getProperties().isEmpty());
+
+        // Verify top-n pushdown capabilities
+        List<OptimizationSubType> topNPushdown = capabilities.get("supports_top_n_pushdown");
+        assertNotNull("Expected supports_top_n_pushdown capability to be present", topNPushdown);
+        assertEquals(1, topNPushdown.size());
+        assertEquals("SUPPORTS_ORDER_BY", topNPushdown.get(0).getSubType());
+    }
+
+    @Test
+    public void convertDatasourceTypeToArrow_DataLakeGen2Types_ReturnsArrowTypes() throws SQLException {
+        ResultSetMetaData metaData = mock(ResultSetMetaData.class);
+        Map<String, String> configOptions = new HashMap<>();
+        int precision = 0;
+
+        Map<String, ArrowType> expectedMappings = new HashMap<>();
+        expectedMappings.put("BIT", org.apache.arrow.vector.types.Types.MinorType.TINYINT.getType());
+        expectedMappings.put("TINYINT", org.apache.arrow.vector.types.Types.MinorType.SMALLINT.getType());
+        expectedMappings.put("NUMERIC", org.apache.arrow.vector.types.Types.MinorType.FLOAT8.getType());
+        expectedMappings.put("SMALLMONEY", org.apache.arrow.vector.types.Types.MinorType.FLOAT8.getType());
+        expectedMappings.put("DATE", org.apache.arrow.vector.types.Types.MinorType.DATEDAY.getType());
+        expectedMappings.put("DATETIME", org.apache.arrow.vector.types.Types.MinorType.DATEMILLI.getType());
+        expectedMappings.put("DATETIME2", org.apache.arrow.vector.types.Types.MinorType.DATEMILLI.getType());
+        expectedMappings.put("SMALLDATETIME", org.apache.arrow.vector.types.Types.MinorType.DATEMILLI.getType());
+        expectedMappings.put("DATETIMEOFFSET", org.apache.arrow.vector.types.Types.MinorType.DATEMILLI.getType());
+
+        int index = 1;
+        for (Map.Entry<String, ArrowType> entry : expectedMappings.entrySet()) {
+            String dataLakeType = entry.getKey();
+            ArrowType expectedArrowType = entry.getValue();
+
+            when(metaData.getColumnTypeName(index)).thenReturn(dataLakeType);
+
+            Optional<ArrowType> actual = dataLakeGen2MetadataHandler.convertDatasourceTypeToArrow(index, precision, configOptions, metaData);
+            assertTrue("Optional value is empty for type " + dataLakeType, actual.isPresent());
+            assertEquals("Failed for type " + dataLakeType, expectedArrowType, actual.get());
+
+            index++;
+        }
+    }
+
+    @Test
+    public void doGetSplits_QueryPassthrough_ReturnsSplitWithProperty()
+    {
+        BlockAllocator blockAllocator = new BlockAllocatorImpl();
+        TableName tableName = new TableName("testSchema", "testTable");
+
+        // Build constraints with query passthrough arguments so isQueryPassThrough() is true
+        Map<String, String> queryPassthroughArguments = new HashMap<>();
+        queryPassthroughArguments.put("queryPassthrough", "true");
+        Constraints constraints = new Constraints(
+                Collections.emptyMap(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Constraints.DEFAULT_NO_LIMIT,
+                queryPassthroughArguments,
+                null
+        );
+
+        GetSplitsRequest getSplitsRequest = new GetSplitsRequest(
+                federatedIdentity,
+                "testQueryId",
+                "testCatalog",
+                tableName,
+                mock(Block.class),
+                Collections.emptyList(),
+                constraints,
+                null
+        );
+
+        GetSplitsResponse getSplitsResponse = dataLakeGen2MetadataHandler.doGetSplits(blockAllocator, getSplitsRequest);
+
+        assertNotNull(getSplitsResponse);
+        assertEquals(1, getSplitsResponse.getSplits().size());
+        Split split = getSplitsResponse.getSplits().iterator().next();
+        Map<String, String> properties = split.getProperties();
+        assertTrue("Split properties should contain query passthrough indicator", properties.containsKey("queryPassthrough"));
+        assertEquals("true", properties.get("queryPassthrough"));
+    }
+
+
+    @Test(expected = RuntimeException.class)
+    public void doGetTable_DataTypeQueryError_ThrowsRuntimeException() throws Exception {
+        TableName tableName = new TableName("testSchema", "testTable");
+
+        String[] columnSchema = {"DATA_TYPE", "COLUMN_SIZE", "COLUMN_NAME", "DECIMAL_DIGITS", "NUM_PREC_RADIX"};
+        Object[][] columnValues = {
+                {Types.INTEGER, 12, "testCol1", 0, 0}
+        };
+        ResultSet columnResultSet = mockResultSet(columnSchema, columnValues, new AtomicInteger(-1));
+        when(connection.getMetaData().getColumns(any(), any(), any(), any())).thenReturn(columnResultSet);
+
+        when(connection.prepareStatement(any())).thenThrow(new RuntimeException(new SQLException("Test error")));
+
+        dataLakeGen2MetadataHandler.doGetTable(
+                new BlockAllocatorImpl(),
+                new GetTableRequest(federatedIdentity, "testQueryId", "testCatalog", tableName, Collections.emptyMap())
+        );
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void doGetSplits_NullPartitions_ThrowsRuntimeException()
+    {
+        TableName tableName = new TableName("testSchema", "testTable");
+        Constraints constraints = new Constraints(
+                Collections.emptyMap(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Constraints.DEFAULT_NO_LIMIT,
+                Collections.emptyMap(),
+                null
+        );
+        
+        GetSplitsRequest getSplitsRequest = new GetSplitsRequest(
+                this.federatedIdentity, 
+                "testQueryId", 
+                "testCatalogName", 
+                tableName, 
+                null, // null partitions
+                new ArrayList<>(), 
+                constraints, 
+                null
+        );
+        
+        this.dataLakeGen2MetadataHandler.doGetSplits(new BlockAllocatorImpl(), getSplitsRequest);
     }
 }

--- a/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MuxRecordHandlerTest.java
+++ b/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MuxRecordHandlerTest.java
@@ -97,7 +97,14 @@ public class DataLakeGen2MuxRecordHandlerTest
         Connection jdbcConnection = Mockito.mock(Connection.class);
         TableName tableName = new TableName("testSchema", "tableName");
         Schema schema = Mockito.mock(Schema.class);
-        Constraints constraints = Mockito.mock(Constraints.class);
+        Constraints constraints = new Constraints(
+                Collections.emptyMap(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Constraints.DEFAULT_NO_LIMIT,
+                Collections.emptyMap(),
+                null
+        );
         Split split = Mockito.mock(Split.class);
         this.jdbcRecordHandler.buildSplitSql(jdbcConnection, DataLakeGen2Constants.NAME, tableName, schema, constraints, split);
         Mockito.verify(this.dataLakeGen2RecordHandler, Mockito.times(1)).buildSplitSql(Mockito.eq(jdbcConnection), Mockito.eq(DataLakeGen2Constants.NAME), Mockito.eq(tableName), Mockito.eq(schema), Mockito.eq(constraints), Mockito.eq(split));

--- a/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeQueryStringBuilderTest.java
+++ b/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeQueryStringBuilderTest.java
@@ -63,8 +63,14 @@ public class DataLakeQueryStringBuilderTest
     {
         Split split = Mockito.mock(Split.class);
         DataLakeGen2QueryStringBuilder builder = new DataLakeGen2QueryStringBuilder(QUOTE_CHARACTER, new DataLakeGen2FederationExpressionParser(QUOTE_CHARACTER));
-        Constraints constraints = Mockito.mock(Constraints.class);
-        Mockito.when(constraints.getLimit()).thenReturn(5L);
+        Constraints constraints = new Constraints(
+                Collections.emptyMap(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                5L,
+                Collections.emptyMap(),
+                null
+        );
         org.testng.Assert.assertEquals("", builder.appendLimitOffset(split, constraints));
     }
 }

--- a/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeRecordHandlerTest.java
+++ b/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeRecordHandlerTest.java
@@ -24,6 +24,8 @@ import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Marker;
+import com.amazonaws.athena.connector.lambda.domain.predicate.OrderByField;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Range;
 import com.amazonaws.athena.connector.lambda.domain.predicate.SortedRangeSet;
 import com.amazonaws.athena.connector.lambda.domain.predicate.ValueSet;
@@ -31,9 +33,11 @@ import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
 import com.amazonaws.athena.connectors.jdbc.connection.JdbcConnectionFactory;
 import com.amazonaws.athena.connector.credentials.CredentialsProvider;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -47,8 +51,15 @@ import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import static com.amazonaws.athena.connectors.datalakegen2.DataLakeGen2Constants.QUOTE_CHARACTER;
+import static com.amazonaws.athena.connector.lambda.metadata.optimizations.querypassthrough.QueryPassthroughSignature.ENABLE_QUERY_PASSTHROUGH;
+import static com.amazonaws.athena.connector.lambda.metadata.optimizations.querypassthrough.QueryPassthroughSignature.SCHEMA_FUNCTION_NAME;
+import static com.amazonaws.athena.connectors.jdbc.qpt.JdbcQueryPassthrough.NAME;
+import static com.amazonaws.athena.connectors.jdbc.qpt.JdbcQueryPassthrough.QUERY;
+import static com.amazonaws.athena.connectors.jdbc.qpt.JdbcQueryPassthrough.SCHEMA_NAME;
 import static org.mockito.ArgumentMatchers.nullable;
 
 public class DataLakeRecordHandlerTest
@@ -79,10 +90,10 @@ public class DataLakeRecordHandlerTest
         this.dataLakeGen2RecordHandler = new DataLakeGen2RecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, com.google.common.collect.ImmutableMap.of());
     }
 
-    private ValueSet getSingleValueSet(Object value) {
+    private ValueSet getSingleValueSet() {
         Range range = Mockito.mock(Range.class, Mockito.RETURNS_DEEP_STUBS);
         Mockito.when(range.isSingleValue()).thenReturn(true);
-        Mockito.when(range.getLow().getValue()).thenReturn(value);
+        Mockito.when(range.getLow().getValue()).thenReturn("varcharTest");
         ValueSet valueSet = Mockito.mock(SortedRangeSet.class, Mockito.RETURNS_DEEP_STUBS);
         Mockito.when(valueSet.getRanges().getOrderedRanges()).thenReturn(Collections.singletonList(range));
         return valueSet;
@@ -104,12 +115,17 @@ public class DataLakeRecordHandlerTest
         Split split = Mockito.mock(Split.class);
         Mockito.when(split.getProperty(DataLakeGen2MetadataHandler.PARTITION_NUMBER)).thenReturn("0");
 
-        ValueSet valueSet = getSingleValueSet("varcharTest");
-        Constraints constraints = Mockito.mock(Constraints.class);
-        Mockito.when(constraints.getSummary()).thenReturn(new ImmutableMap.Builder<String, ValueSet>()
-                .put("testCol4", valueSet)
-                .build());
-        Mockito.when(constraints.getLimit()).thenReturn(5L);
+        ValueSet valueSet = getSingleValueSet();
+        Constraints constraints = new Constraints(
+                new ImmutableMap.Builder<@NotNull String, @NotNull ValueSet>()
+                        .put("testCol4", valueSet)
+                        .build(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                5L,
+                Collections.emptyMap(),
+                null
+        );
 
         String expectedSql = "SELECT \"testCol1\", \"testCol2\", \"testCol3\", \"testCol4\" FROM \"testSchema\".\"testTable\"  WHERE (\"testCol4\" = ?)";
         PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
@@ -121,7 +137,7 @@ public class DataLakeRecordHandlerTest
     }
 
     @Test
-    public void testReadWithConstraintWithAzureServerlessEnvironment()
+    public void readWithConstraint_AzureServerlessEnvironment()
             throws Exception
     {
         // Mock Azure serverless URL
@@ -152,7 +168,7 @@ public class DataLakeRecordHandlerTest
         Mockito.when(mockReadRecordsRequest.getCatalogName()).thenReturn("testCatalog");
         Mockito.when(mockReadRecordsRequest.getTableName()).thenReturn(new TableName("testSchema", "testTable"));
         Mockito.when(mockReadRecordsRequest.getSchema()).thenReturn(SchemaBuilder.newBuilder().build());
-        Mockito.when(mockReadRecordsRequest.getConstraints()).thenReturn(Mockito.mock(Constraints.class));
+        Mockito.when(mockReadRecordsRequest.getConstraints()).thenReturn(createEmptyConstraint());
         Mockito.when(mockReadRecordsRequest.getSplit()).thenReturn(Mockito.mock(Split.class));
 
         // Execute the method
@@ -166,7 +182,7 @@ public class DataLakeRecordHandlerTest
     }
 
     @Test
-    public void testReadWithConstraintWithStandardEnvironment()
+    public void readWithConstraint_StandardEnvironment()
             throws Exception
     {
         // Mock standard SQL Server URL (non-serverless)
@@ -197,7 +213,7 @@ public class DataLakeRecordHandlerTest
         Mockito.when(mockReadRecordsRequest.getCatalogName()).thenReturn("testCatalog");
         Mockito.when(mockReadRecordsRequest.getTableName()).thenReturn(new TableName("testSchema", "testTable"));
         Mockito.when(mockReadRecordsRequest.getSchema()).thenReturn(SchemaBuilder.newBuilder().build());
-        Mockito.when(mockReadRecordsRequest.getConstraints()).thenReturn(Mockito.mock(Constraints.class));
+        Mockito.when(mockReadRecordsRequest.getConstraints()).thenReturn(createEmptyConstraint());
         Mockito.when(mockReadRecordsRequest.getSplit()).thenReturn(Mockito.mock(Split.class));
 
         // Execute the method
@@ -208,5 +224,565 @@ public class DataLakeRecordHandlerTest
         
         // Verify that commit() WAS called for standard environment
         Mockito.verify(connection, Mockito.times(1)).commit();
+    }
+
+    @Test
+    public void buildSplitSql_ComplexMixedPredicates_ReturnsPreparedStatement() throws SQLException
+    {
+        TableName tableName = new TableName("testSchema", "testTable");
+
+        SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
+        schemaBuilder.addField(FieldBuilder.newBuilder("id", Types.MinorType.INT.getType()).build());
+        schemaBuilder.addField(FieldBuilder.newBuilder("name", Types.MinorType.VARCHAR.getType()).build());
+        schemaBuilder.addField(FieldBuilder.newBuilder("age", Types.MinorType.INT.getType()).build());
+        schemaBuilder.addField(FieldBuilder.newBuilder("salary", Types.MinorType.FLOAT8.getType()).build());
+        schemaBuilder.addField(FieldBuilder.newBuilder("department", Types.MinorType.VARCHAR.getType()).build());
+        schemaBuilder.addField(FieldBuilder.newBuilder("is_active", Types.MinorType.BIT.getType()).build());
+        schemaBuilder.addField(FieldBuilder.newBuilder("amount", Types.MinorType.FLOAT8.getType()).build());
+        Schema schema = schemaBuilder.build();
+
+        Split split = createTestSplit();
+
+        // Create complex constraints with multiple predicate types
+        ValueSet idSet = createMultiValueSet(1, 2, 3, 4, 5);
+        ValueSet ageSet = createRangeSet(Marker.Bound.EXACTLY, 25, Marker.Bound.EXACTLY, 65);
+        ValueSet salarySet = createRangeSet(Marker.Bound.ABOVE, 50000.0, Marker.Bound.BELOW, Double.MAX_VALUE);
+        ValueSet deptSet = createSingleValueSet("IT");
+        ValueSet activeSet = createSingleValueSet(true);
+        ValueSet amountSet = createSingleValueSet(1234.56);
+
+        Constraints constraints = new Constraints(
+                ImmutableMap.of(
+                        "id", idSet,
+                        "age", ageSet,
+                        "salary", salarySet,
+                        "department", deptSet,
+                        "is_active", activeSet,
+                        "amount", amountSet
+                ),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Constraints.DEFAULT_NO_LIMIT,
+                Collections.emptyMap(),
+                null
+        );
+
+        String expectedSql = "SELECT \"id\", \"name\", \"age\", \"salary\", \"department\", \"is_active\", \"amount\" FROM \"testSchema\".\"testTable\"  WHERE (\"id\" IN (?,?,?,?,?)) AND ((\"age\" >= ? AND \"age\" <= ?)) AND ((\"salary\" > ? AND \"salary\" < ?)) AND (\"department\" = ?) AND (\"is_active\" = ?) AND (\"amount\" = ?)";
+        PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(this.connection.prepareStatement(Mockito.eq(expectedSql))).thenReturn(expectedPreparedStatement);
+        Mockito.when(expectedPreparedStatement.getConnection()).thenReturn(this.connection);
+        
+        PreparedStatement preparedStatement = this.dataLakeGen2RecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
+
+        Assert.assertEquals(expectedPreparedStatement, preparedStatement);
+
+        Mockito.verify(preparedStatement, Mockito.times(1)).setInt(1, 1);
+        Mockito.verify(preparedStatement, Mockito.times(1)).setInt(2, 2);
+        Mockito.verify(preparedStatement, Mockito.times(1)).setInt(3, 3);
+        Mockito.verify(preparedStatement, Mockito.times(1)).setInt(4, 4);
+        Mockito.verify(preparedStatement, Mockito.times(1)).setInt(5, 5);
+        Mockito.verify(preparedStatement, Mockito.times(1)).setInt(6, 25);
+        Mockito.verify(preparedStatement, Mockito.times(1)).setInt(7, 65);
+        Mockito.verify(preparedStatement, Mockito.times(1)).setDouble(8, 50000.0);
+        Mockito.verify(preparedStatement, Mockito.times(1)).setDouble(9, Double.MAX_VALUE);
+        Mockito.verify(preparedStatement, Mockito.times(1)).setString(10, "IT");
+        Mockito.verify(preparedStatement, Mockito.times(1)).setBoolean(11, true);
+        Mockito.verify(preparedStatement, Mockito.times(1)).setDouble(12, 1234.56);
+    }
+
+    @Test
+    public void buildSplitSql_RangePredicates_ReturnsPreparedStatement() throws SQLException
+    {
+        TableName tableName = new TableName("testSchema", "testTable");
+
+        SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
+        schemaBuilder.addField(FieldBuilder.newBuilder("price", Types.MinorType.FLOAT8.getType()).build());
+        schemaBuilder.addField(FieldBuilder.newBuilder("quantity", Types.MinorType.INT.getType()).build());
+        schemaBuilder.addField(FieldBuilder.newBuilder("discount", Types.MinorType.FLOAT4.getType()).build());
+        Schema schema = schemaBuilder.build();
+
+        Split split = createTestSplit();
+
+        // Complex range predicates with valid bounds
+        ValueSet priceSet = createRangeSet(Marker.Bound.ABOVE, 100.0, Marker.Bound.EXACTLY, 1000.0);
+        ValueSet quantitySet = createRangeSet(Marker.Bound.EXACTLY, 10, Marker.Bound.BELOW, 100);
+        ValueSet discountSet = createRangeSet(Marker.Bound.ABOVE, 0.05f, Marker.Bound.BELOW, 0.5f);
+
+        Constraints constraints = new Constraints(
+                ImmutableMap.of(
+                        "price", priceSet,
+                        "quantity", quantitySet,
+                        "discount", discountSet
+                ),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Constraints.DEFAULT_NO_LIMIT,
+                Collections.emptyMap(),
+                null
+        );
+
+        String expectedSql = "SELECT \"price\", \"quantity\", \"discount\" FROM \"testSchema\".\"testTable\"  WHERE ((\"price\" > ? AND \"price\" <= ?)) AND ((\"quantity\" >= ? AND \"quantity\" < ?)) AND ((\"discount\" > ? AND \"discount\" < ?))";
+        PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(this.connection.prepareStatement(Mockito.eq(expectedSql))).thenReturn(expectedPreparedStatement);
+        
+        PreparedStatement preparedStatement = this.dataLakeGen2RecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
+
+        Assert.assertEquals(expectedPreparedStatement, preparedStatement);
+        
+        // Verify parameter setting for range constraints
+        Mockito.verify(preparedStatement, Mockito.times(1)).setDouble(1, 100.0);
+        Mockito.verify(preparedStatement, Mockito.times(1)).setDouble(2, 1000.0);
+        Mockito.verify(preparedStatement, Mockito.times(1)).setInt(3, 10);
+        Mockito.verify(preparedStatement, Mockito.times(1)).setInt(4, 100);
+        Mockito.verify(preparedStatement, Mockito.times(1)).setFloat(5, 0.05f);
+        Mockito.verify(preparedStatement, Mockito.times(1)).setFloat(6, 0.5f);
+    }
+
+    @Test
+    public void buildSplitSql_OrderBy_ReturnsPreparedStatement() throws SQLException
+    {
+        TableName tableName = new TableName("testSchema", "testTable");
+
+        SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
+        schemaBuilder.addField(FieldBuilder.newBuilder("id", Types.MinorType.INT.getType()).build());
+        schemaBuilder.addField(FieldBuilder.newBuilder("name", Types.MinorType.VARCHAR.getType()).build());
+        schemaBuilder.addField(FieldBuilder.newBuilder("salary", Types.MinorType.FLOAT8.getType()).build());
+        Schema schema = schemaBuilder.build();
+
+        Split split = createTestSplit();
+
+        OrderByField orderByField = new OrderByField("salary", OrderByField.Direction.DESC_NULLS_LAST);
+        Constraints constraints = new Constraints(
+                Collections.emptyMap(),
+                Collections.emptyList(),
+                ImmutableList.of(orderByField),
+                10, // limit
+                Collections.emptyMap(),
+                null
+        );
+
+        String expectedSql = "SELECT \"id\", \"name\", \"salary\" FROM \"testSchema\".\"testTable\"  ORDER BY \"salary\" DESC NULLS LAST";
+        PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(this.connection.prepareStatement(Mockito.eq(expectedSql))).thenReturn(expectedPreparedStatement);
+        
+        PreparedStatement preparedStatement = this.dataLakeGen2RecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
+
+        Assert.assertEquals(expectedPreparedStatement, preparedStatement);
+    }
+
+    @Test
+    public void buildSplitSql_MultipleOrderByFields_ReturnsPreparedStatement() throws SQLException
+    {
+        TableName tableName = new TableName("testSchema", "testTable");
+
+        SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
+        schemaBuilder.addField(FieldBuilder.newBuilder("department", Types.MinorType.VARCHAR.getType()).build());
+        schemaBuilder.addField(FieldBuilder.newBuilder("salary", Types.MinorType.FLOAT8.getType()).build());
+        schemaBuilder.addField(FieldBuilder.newBuilder("name", Types.MinorType.VARCHAR.getType()).build());
+        Schema schema = schemaBuilder.build();
+
+        Split split = createTestSplit();
+
+        // Multiple ORDER BY fields with different directions
+        OrderByField orderByField1 = new OrderByField("department", OrderByField.Direction.ASC_NULLS_LAST);
+        OrderByField orderByField2 = new OrderByField("salary", OrderByField.Direction.DESC_NULLS_FIRST);
+        OrderByField orderByField3 = new OrderByField("name", OrderByField.Direction.ASC_NULLS_LAST);
+
+        Constraints constraints = new Constraints(
+                Collections.emptyMap(),
+                Collections.emptyList(),
+                ImmutableList.of(orderByField1, orderByField2, orderByField3),
+                Constraints.DEFAULT_NO_LIMIT,
+                Collections.emptyMap(),
+                null
+        );
+
+        String expectedSql = "SELECT \"department\", \"salary\", \"name\" FROM \"testSchema\".\"testTable\"  ORDER BY \"department\" ASC NULLS LAST, \"salary\" DESC NULLS FIRST, \"name\" ASC NULLS LAST";
+        PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(this.connection.prepareStatement(Mockito.eq(expectedSql))).thenReturn(expectedPreparedStatement);
+        Mockito.when(expectedPreparedStatement.getConnection()).thenReturn(this.connection);
+        
+        PreparedStatement preparedStatement = this.dataLakeGen2RecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
+
+        Assert.assertEquals(expectedPreparedStatement, preparedStatement);
+    }
+
+    @Test
+    public void buildSplitSql_EmptyConstraints_ReturnsPreparedStatement() throws SQLException
+    {
+        TableName tableName = new TableName("testSchema", "testTable");
+
+        SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
+        schemaBuilder.addField(FieldBuilder.newBuilder("id", Types.MinorType.INT.getType()).build());
+        Schema schema = schemaBuilder.build();
+
+        Split split = createTestSplit();
+
+        // Empty constraints
+        Constraints constraints = createEmptyConstraint();
+
+        String expectedSql = "SELECT \"id\" FROM \"testSchema\".\"testTable\" ";
+        PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(this.connection.prepareStatement(Mockito.eq(expectedSql))).thenReturn(expectedPreparedStatement);
+        
+        PreparedStatement preparedStatement = this.dataLakeGen2RecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
+
+        Assert.assertEquals(expectedPreparedStatement, preparedStatement);
+    }
+
+    @Test
+    public void buildSplitSql_SingleValueInClause_ReturnsPreparedStatement() throws SQLException
+    {
+        TableName tableName = new TableName("testSchema", "testTable");
+
+        SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
+        schemaBuilder.addField(FieldBuilder.newBuilder("id", Types.MinorType.INT.getType()).build());
+        Schema schema = schemaBuilder.build();
+
+        Split split = createTestSplit();
+
+        // Single value should use equality, not IN clause
+        ValueSet singleValueSet = createSingleValueSet(1);
+        Constraints constraints = new Constraints(
+                ImmutableMap.of("id", singleValueSet),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Constraints.DEFAULT_NO_LIMIT,
+                Collections.emptyMap(),
+                null
+        );
+
+        String expectedSql = "SELECT \"id\" FROM \"testSchema\".\"testTable\"  WHERE (\"id\" = ?)";
+        PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(this.connection.prepareStatement(Mockito.eq(expectedSql))).thenReturn(expectedPreparedStatement);
+        
+        PreparedStatement preparedStatement = this.dataLakeGen2RecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
+
+        Assert.assertEquals(expectedPreparedStatement, preparedStatement);
+        
+        // Verify parameter setting for single value
+        Mockito.verify(preparedStatement, Mockito.times(1)).setInt(1, 1);
+    }
+
+    @Test
+    public void buildSplitSql_LargeInClause_ReturnsPreparedStatement() throws SQLException
+    {
+        TableName tableName = new TableName("testSchema", "testTable");
+
+        SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
+        schemaBuilder.addField(FieldBuilder.newBuilder("id", Types.MinorType.INT.getType()).build());
+        Schema schema = schemaBuilder.build();
+
+        Split split = createTestSplit();
+
+        // Large IN clause with many values
+        ValueSet largeInSet = createMultiValueSet(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+        Constraints constraints = new Constraints(
+                ImmutableMap.of("id", largeInSet),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Constraints.DEFAULT_NO_LIMIT,
+                Collections.emptyMap(),
+                null
+        );
+
+        String expectedSql = "SELECT \"id\" FROM \"testSchema\".\"testTable\"  WHERE (\"id\" IN (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?))";
+        PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(this.connection.prepareStatement(Mockito.eq(expectedSql))).thenReturn(expectedPreparedStatement);
+        
+        PreparedStatement preparedStatement = this.dataLakeGen2RecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
+
+        Assert.assertEquals(expectedPreparedStatement, preparedStatement);
+        for (int i = 1; i <= 15; i++) {
+            Mockito.verify(preparedStatement, Mockito.times(1)).setInt(i, i);
+        }
+    }
+
+    @Test(expected = SQLException.class)
+    public void buildSplitSql_InvalidConnection_ThrowsSQLException() throws SQLException
+    {
+        TableName tableName = new TableName("testSchema", "testTable");
+        Schema schema = SchemaBuilder.newBuilder()
+                .addField(FieldBuilder.newBuilder("id", Types.MinorType.INT.getType()).build())
+                .build();
+        Split split = createTestSplit();
+        Constraints constraints = createEmptyConstraint();
+        Connection invalidConnection = Mockito.mock(Connection.class);
+        Mockito.when(invalidConnection.prepareStatement(Mockito.anyString())).thenThrow(new SQLException("Connection error"));
+
+        this.dataLakeGen2RecordHandler.buildSplitSql(invalidConnection, "testCatalog", tableName, schema, constraints, split);
+    }
+
+    @Test
+    public void buildSplitSql_NullTableName_ThrowsException()
+    {
+        Schema schema = SchemaBuilder.newBuilder()
+                .addField(FieldBuilder.newBuilder("id", Types.MinorType.INT.getType()).build())
+                .build();
+        Split split = createTestSplit();
+        Constraints constraints = createEmptyConstraint();
+
+        try {
+            this.dataLakeGen2RecordHandler.buildSplitSql(this.connection, "testCatalog", null, schema, constraints, split);
+            Assert.fail("Should have thrown exception for null table name");
+        } catch (Exception e) {
+            // Expected to fail with null table name
+            Assert.assertNotNull("Should throw exception for null table name", e);
+        }
+    }
+
+    @Test
+    public void buildSplitSql_LimitConstraint_IgnoresLimit() throws SQLException
+    {
+        TableName tableName = new TableName("testSchema", "testTable");
+
+        SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
+        schemaBuilder.addField(FieldBuilder.newBuilder("id", Types.MinorType.INT.getType()).build());
+        schemaBuilder.addField(FieldBuilder.newBuilder("name", Types.MinorType.VARCHAR.getType()).build());
+        Schema schema = schemaBuilder.build();
+
+        Split split = createTestSplit();
+
+        // Test LIMIT constraint (should be ignored by DataLakeGen2)
+        Constraints constraints = new Constraints(
+                Collections.emptyMap(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                100L, // limit
+                Collections.emptyMap(),
+                null
+        );
+
+        // DataLakeGen2 doesn't support LIMIT, so it should be ignored
+        String expectedSql = "SELECT \"id\", \"name\" FROM \"testSchema\".\"testTable\" ";
+        PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(this.connection.prepareStatement(Mockito.eq(expectedSql))).thenReturn(expectedPreparedStatement);
+        Mockito.when(expectedPreparedStatement.getConnection()).thenReturn(this.connection);
+        
+        PreparedStatement preparedStatement = this.dataLakeGen2RecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
+
+        Assert.assertEquals(expectedPreparedStatement, preparedStatement);
+    }
+
+    @Test
+    public void buildSplitSql_QueryPassthrough_ReturnsPassthroughQuery() throws SQLException
+    {
+        TableName tableName = new TableName("testSchema", "testTable");
+
+        SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
+        schemaBuilder.addField(FieldBuilder.newBuilder("testCol1", Types.MinorType.INT.getType()).build());
+        schemaBuilder.addField(FieldBuilder.newBuilder("partition", Types.MinorType.VARCHAR.getType()).build());
+        Schema schema = schemaBuilder.build();
+
+        Split split = Mockito.mock(Split.class);
+        Mockito.when(split.getProperties()).thenReturn(Collections.singletonMap("partition", "p0"));
+        Mockito.when(split.getProperty(Mockito.eq("partition"))).thenReturn("p0");
+
+        String testQuery = String.format("SELECT * FROM %s.%s WHERE %s = 1", "testSchema", "testTable", "testCol1");
+        Map<String, String> queryPassthroughArgs = new com.google.common.collect.ImmutableMap.Builder<@NotNull String, @NotNull String>()
+                .put(QUERY, testQuery)
+                .put(SCHEMA_FUNCTION_NAME, "system.query")
+                .put(ENABLE_QUERY_PASSTHROUGH, "true")
+                .put("name", NAME)
+                .put("schema", SCHEMA_NAME)
+                .build();
+
+        Constraints constraints = new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(),
+                Constraints.DEFAULT_NO_LIMIT, queryPassthroughArgs, null);
+
+        PreparedStatement expectedPreparedStatement = createMockPreparedStatement(testQuery);
+        PreparedStatement preparedStatement = this.dataLakeGen2RecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
+
+        Assert.assertEquals(expectedPreparedStatement, preparedStatement);
+        Mockito.verify(this.connection).prepareStatement(testQuery);
+    }
+
+    @Test
+    public void buildSplitSql_PassthroughDisabled_ReturnsPreparedStatement() throws SQLException
+    {
+        TableName tableName = new TableName("testSchema", "testTable");
+        Schema schema = createTestSchema();
+        Split split = createMockSplit();
+
+        ValueSet intValueSet = createSingleValueSet(123);
+        ValueSet varcharValueSet = createSingleValueSet("abc");
+
+        Constraints constraints = new Constraints(
+                com.google.common.collect.ImmutableMap.of("intCol", intValueSet, "varcharCol", varcharValueSet),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Constraints.DEFAULT_NO_LIMIT,
+                Collections.emptyMap(),
+                null);
+
+        Assert.assertFalse("Expected isQueryPassThrough to return false", constraints.isQueryPassThrough());
+
+        String expectedSql = "SELECT \"intCol\", \"varcharCol\", \"bigintCol\", \"floatCol\", \"doubleCol\", \"dateCol\", \"timestampCol\", \"boolCol\" FROM \"testSchema\".\"testTable\"  WHERE (\"intCol\" = ?) AND (\"varcharCol\" = ?)";
+        PreparedStatement expectedPreparedStatement = createMockPreparedStatement(expectedSql);
+
+        PreparedStatement result = this.dataLakeGen2RecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
+        Assert.assertEquals(expectedPreparedStatement, result);
+        Mockito.verify(result, Mockito.times(1)).setInt(1, 123);
+        Mockito.verify(result, Mockito.times(1)).setString(2, "abc");
+        Mockito.verify(this.connection).prepareStatement(expectedSql);
+    }
+
+    @Test
+    public void buildSplitSql_PassthroughEnabledMissingQuery_ThrowsException() throws SQLException
+    {
+        TableName tableName = new TableName("testSchema", "testTable");
+        Schema schema = createTestSchema();
+        Split split = createMockSplit();
+
+        Map<String, String> queryPassthroughArgs = new com.google.common.collect.ImmutableMap.Builder<@NotNull String, @NotNull String>()
+                .put(SCHEMA_FUNCTION_NAME, "system.query")
+                .put(ENABLE_QUERY_PASSTHROUGH, "true")
+                .put("name", NAME)
+                .put("schema", SCHEMA_NAME)
+                .build();
+
+        Constraints constraints = new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(),
+                Constraints.DEFAULT_NO_LIMIT, queryPassthroughArgs, null);
+
+        Assert.assertTrue("Expected isQueryPassThrough to return true", constraints.isQueryPassThrough());
+
+        try {
+            this.dataLakeGen2RecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
+            Assert.fail("Expected exception to be thrown");
+        }
+        catch (RuntimeException e) {
+            Assert.assertTrue(e.getMessage().contains("Missing Query Passthrough Argument"));
+        }
+    }
+
+    @Test
+    public void buildSplitSql_PassthroughWrongSchema_ThrowsException() throws SQLException
+    {
+        TableName tableName = new TableName("testSchema", "testTable");
+        Schema schema = createTestSchema();
+        Split split = createMockSplit();
+
+        String testQuery = String.format("SELECT * FROM %s.%s WHERE %s = 1", "testSchema", "testTable", "testCol1");
+        Map<String, String> queryPassthroughArgs = new com.google.common.collect.ImmutableMap.Builder<@NotNull String, @NotNull String>()
+                .put(QUERY, testQuery)
+                .put(SCHEMA_FUNCTION_NAME, "wrong.function")
+                .put(ENABLE_QUERY_PASSTHROUGH, "true")
+                .put("name", NAME)
+                .put("schema", SCHEMA_NAME)
+                .build();
+
+        Constraints constraints = new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(),
+                Constraints.DEFAULT_NO_LIMIT, queryPassthroughArgs, null);
+
+        Assert.assertTrue("Expected isQueryPassThrough to return true", constraints.isQueryPassThrough());
+
+        try {
+            this.dataLakeGen2RecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
+            Assert.fail("Expected exception to be thrown");
+        }
+        catch (RuntimeException e) {
+            Assert.assertTrue(e.getMessage().contains("Function Signature doesn't match implementation's"));
+        }
+    }
+
+    /**
+     * Helper method to create a single value ValueSet without mocking
+     */
+    private ValueSet createSingleValueSet(Object value)
+    {
+        Range range = Mockito.mock(Range.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(range.isSingleValue()).thenReturn(true);
+        Mockito.when(range.getLow().getValue()).thenReturn(value);
+        ValueSet valueSet = Mockito.mock(SortedRangeSet.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(valueSet.getRanges().getOrderedRanges()).thenReturn(Collections.singletonList(range));
+        return valueSet;
+    }
+
+    /**
+     * Helper method to create a multi-value ValueSet (for IN clauses)
+     */
+    private ValueSet createMultiValueSet(Object... values)
+    {
+        java.util.List<Range> ranges = new java.util.ArrayList<>();
+        for (Object value : values) {
+            Range range = Mockito.mock(Range.class, Mockito.RETURNS_DEEP_STUBS);
+            Mockito.when(range.isSingleValue()).thenReturn(true);
+            Mockito.when(range.getLow().getValue()).thenReturn(value);
+            ranges.add(range);
+        }
+        ValueSet valueSet = Mockito.mock(SortedRangeSet.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(valueSet.getRanges().getOrderedRanges()).thenReturn(ranges);
+        return valueSet;
+    }
+
+    /**
+     * Helper method to create a range ValueSet
+     */
+    private ValueSet createRangeSet(Marker.Bound lowerBound, Object lowerValue, Marker.Bound upperBound, Object upperValue)
+    {
+        Range range = Mockito.mock(Range.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(range.isSingleValue()).thenReturn(false);
+        Mockito.when(range.getLow().getValue()).thenReturn(lowerValue);
+        Mockito.when(range.getHigh().getValue()).thenReturn(upperValue);
+        Mockito.when(range.getLow().getBound()).thenReturn(lowerBound);
+        Mockito.when(range.getHigh().getBound()).thenReturn(upperBound);
+        ValueSet valueSet = Mockito.mock(SortedRangeSet.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(valueSet.getRanges().getOrderedRanges()).thenReturn(Collections.singletonList(range));
+        return valueSet;
+    }
+
+    /**
+     * Helper method to create base split for testing
+     */
+    private Split createTestSplit()
+    {
+        Split split = Mockito.mock(Split.class);
+        Map<String, String> properties = new HashMap<>();
+        properties.put(DataLakeGen2MetadataHandler.PARTITION_NUMBER, "0");
+        Mockito.when(split.getProperties()).thenReturn(properties);
+        Mockito.when(split.getProperty(Mockito.eq(DataLakeGen2MetadataHandler.PARTITION_NUMBER))).thenReturn("0");
+        Mockito.when(split.getProperty(Mockito.anyString())).thenReturn("0");
+        return split;
+    }
+
+    private Schema createTestSchema()
+    {
+        SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
+        schemaBuilder.addField(FieldBuilder.newBuilder("intCol", Types.MinorType.INT.getType()).build());
+        schemaBuilder.addField(FieldBuilder.newBuilder("varcharCol", Types.MinorType.VARCHAR.getType()).build());
+        schemaBuilder.addField(FieldBuilder.newBuilder("bigintCol", Types.MinorType.BIGINT.getType()).build());
+        schemaBuilder.addField(FieldBuilder.newBuilder("floatCol", Types.MinorType.FLOAT4.getType()).build());
+        schemaBuilder.addField(FieldBuilder.newBuilder("doubleCol", Types.MinorType.FLOAT8.getType()).build());
+        schemaBuilder.addField(FieldBuilder.newBuilder("dateCol", Types.MinorType.DATEDAY.getType()).build());
+        schemaBuilder.addField(FieldBuilder.newBuilder("timestampCol", Types.MinorType.DATEMILLI.getType()).build());
+        schemaBuilder.addField(FieldBuilder.newBuilder("boolCol", Types.MinorType.BIT.getType()).build());
+        return schemaBuilder.build();
+    }
+
+    private Split createMockSplit()
+    {
+        Split split = Mockito.mock(Split.class);
+        Mockito.when(split.getProperty(DataLakeGen2MetadataHandler.PARTITION_NUMBER)).thenReturn("0");
+        return split;
+    }
+
+    private PreparedStatement createMockPreparedStatement(String expectedSql) throws SQLException
+    {
+        PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(this.connection.prepareStatement(Mockito.eq(expectedSql)))
+                .thenReturn(preparedStatement);
+        return preparedStatement;
+    }
+
+    private Constraints createEmptyConstraint()
+    {
+        return new Constraints(
+                Collections.emptyMap(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Constraints.DEFAULT_NO_LIMIT,
+                Collections.emptyMap(),
+                null
+        );
     }
 }

--- a/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/resolver/DataLakeGen2CaseResolverTest.java
+++ b/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/resolver/DataLakeGen2CaseResolverTest.java
@@ -1,0 +1,200 @@
+/*-
+ * #%L
+ * athena-datalakegen2
+ * %%
+ * Copyright (C) 2019 - 2025 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.datalakegen2.resolver;
+
+import com.amazonaws.athena.connector.lambda.domain.TableName;
+import com.amazonaws.athena.connector.lambda.resolver.CaseResolver;
+import com.amazonaws.athena.connectors.jdbc.TestBase;
+import com.amazonaws.athena.connectors.jdbc.resolver.DefaultJDBCCaseResolver;
+import com.amazonaws.athena.connectors.datalakegen2.DataLakeGen2Constants;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.amazonaws.athena.connector.lambda.resolver.CaseResolver.CASING_MODE_CONFIGURATION_KEY;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+public class DataLakeGen2CaseResolverTest extends TestBase
+{
+    private Connection mockConnection;
+    private PreparedStatement preparedStatement;
+
+    @Before
+    public void setUp() throws SQLException
+    {
+        mockConnection = Mockito.mock(Connection.class);
+        preparedStatement = Mockito.mock(PreparedStatement.class);
+        when(mockConnection.prepareStatement(any())).thenReturn(preparedStatement);
+    }
+
+    @Test
+    public void getAdjustedSchemaNameString_CaseInsensitiveSearch_ReturnsLowerCasedSchemaAndTableName() throws SQLException
+    {
+        String schemaName = "TeStScHeMa";
+        String tableName = "TeStTaBlE";
+        DefaultJDBCCaseResolver resolver = new DataLakeGen2CaseResolver(DataLakeGen2Constants.NAME);
+        mockSchemaAndTable(schemaName, tableName);
+
+        String adjustedSchemaName = resolver.getAdjustedSchemaNameString(mockConnection, schemaName, Map.of(
+                CASING_MODE_CONFIGURATION_KEY, CaseResolver.FederationSDKCasingMode.CASE_INSENSITIVE_SEARCH.name()));
+        assertEquals(schemaName.toLowerCase(), adjustedSchemaName);
+
+        String adjustedTableName = resolver.getAdjustedTableNameString(mockConnection, schemaName, tableName, Map.of(
+                CASING_MODE_CONFIGURATION_KEY, CaseResolver.FederationSDKCasingMode.CASE_INSENSITIVE_SEARCH.name()));
+        assertEquals(tableName.toLowerCase(), adjustedTableName);
+    }
+
+    @Test
+    public void getAdjustedTableNameObject_CaseInsensitiveSearch_ReturnsLowerCasedTableNameObject() throws SQLException
+    {
+        String schemaName = "TeStScHeMa";
+        String tableName = "TeStTaBlE";
+        DefaultJDBCCaseResolver resolver = new DataLakeGen2CaseResolver(DataLakeGen2Constants.NAME);
+        mockSchemaAndTable(schemaName, tableName);
+
+        TableName adjusted = resolver.getAdjustedTableNameObject(
+                mockConnection,
+                new TableName(schemaName, tableName),
+                Map.of(CASING_MODE_CONFIGURATION_KEY, CaseResolver.FederationSDKCasingMode.CASE_INSENSITIVE_SEARCH.name()));
+        assertEquals(new TableName(schemaName.toLowerCase(), tableName.toLowerCase()), adjusted);
+    }
+
+    @Test
+    public void getAdjustedSchemaNameString_NoMatch_ReturnsOriginalSchemaAndTableName() throws SQLException
+    {
+        String schemaName = "NonExistentSchema";
+        DefaultJDBCCaseResolver resolver = new DataLakeGen2CaseResolver(DataLakeGen2Constants.NAME);
+
+        ResultSet emptyResultSet = mockResultSet(
+                new String[]{"SCHEMA_NAME"},
+                new int[]{Types.VARCHAR},
+                new Object[][]{},
+                new AtomicInteger(-1));
+
+        when(preparedStatement.executeQuery()).thenReturn(emptyResultSet);
+
+        String adjustedSchemaName = resolver.getAdjustedSchemaNameString(mockConnection, schemaName, Map.of(
+                CASING_MODE_CONFIGURATION_KEY, CaseResolver.FederationSDKCasingMode.NONE.name()));
+        assertEquals(schemaName, adjustedSchemaName);
+
+        String tableName = "NonExistentTable";
+        ResultSet emptyTableResultSet = mockResultSet(
+                new String[]{"TABLE_NAME"},
+                new int[]{Types.VARCHAR},
+                new Object[][]{},
+                new AtomicInteger(-1));
+
+        when(preparedStatement.executeQuery()).thenReturn(emptyTableResultSet);
+
+        String adjustedTableName = resolver.getAdjustedTableNameString(mockConnection, schemaName, tableName, Map.of(
+                CASING_MODE_CONFIGURATION_KEY, CaseResolver.FederationSDKCasingMode.NONE.name()));
+        assertEquals(tableName, adjustedTableName);
+    }
+
+    @Test
+    public void getAdjustedSchemaNameString_EmptyConfig_ReturnsOriginalSchemaName() throws SQLException
+    {
+        String schemaName = "TestSchema";
+        DefaultJDBCCaseResolver resolver = new DataLakeGen2CaseResolver(DataLakeGen2Constants.NAME);
+
+        ResultSet emptyResultSet = mockResultSet(
+                new String[]{"SCHEMA_NAME"},
+                new int[]{Types.VARCHAR},
+                new Object[][]{},
+                new AtomicInteger(-1));
+
+        when(preparedStatement.executeQuery()).thenReturn(emptyResultSet);
+
+        // Test with empty configuration map - should default to original name
+        String adjustedSchemaName = resolver.getAdjustedSchemaNameString(mockConnection, schemaName, Map.of());
+        
+        assertEquals(schemaName, adjustedSchemaName);
+    }
+    
+    @Test
+    public void getAdjustedTableNameObject_NoMatch_ReturnsOriginalTableNameObject() throws SQLException
+    {
+        String schemaName = "NonExistentSchema";
+        String tableName = "NonExistentTable";
+        DefaultJDBCCaseResolver resolver = new DataLakeGen2CaseResolver(DataLakeGen2Constants.NAME);
+
+        ResultSet emptyResultSet = mockResultSet(
+                new String[]{"SCHEMA_NAME", "TABLE_NAME"},
+                new int[]{Types.VARCHAR, Types.VARCHAR},
+                new Object[][]{},
+                new AtomicInteger(-1));
+
+        when(preparedStatement.executeQuery()).thenReturn(emptyResultSet);
+
+        TableName adjusted = resolver.getAdjustedTableNameObject(
+                mockConnection,
+                new TableName(schemaName, tableName),
+                Map.of(CASING_MODE_CONFIGURATION_KEY, CaseResolver.FederationSDKCasingMode.NONE.name()));
+        assertEquals(new TableName(schemaName, tableName), adjusted);
+    }
+
+    @Test
+    public void getAdjustedTableNameObject_EmptyConfig_ReturnsOriginalTableNameObject() throws SQLException
+    {
+        String schemaName = "TestSchema";
+        String tableName = "TestTable";
+        DefaultJDBCCaseResolver resolver = new DataLakeGen2CaseResolver(DataLakeGen2Constants.NAME);
+
+        ResultSet emptyResultSet = mockResultSet(
+                new String[]{"SCHEMA_NAME", "TABLE_NAME"},
+                new int[]{Types.VARCHAR, Types.VARCHAR},
+                new Object[][]{},
+                new AtomicInteger(-1));
+
+        when(preparedStatement.executeQuery()).thenReturn(emptyResultSet);
+
+        // Test with empty configuration map - should default to original name
+        TableName adjusted = resolver.getAdjustedTableNameObject(
+                mockConnection,
+                new TableName(schemaName, tableName),
+                Map.of());
+        assertEquals(new TableName(schemaName, tableName), adjusted);
+    }
+
+    private void mockSchemaAndTable(String schemaName, String tableName) throws SQLException
+    {
+        String[] schemaCols = {"SCHEMA_NAME"};
+        int[] schemaTypes = {Types.VARCHAR};
+        Object[][] schemaData = {{schemaName.toLowerCase()}};
+        ResultSet schemaResultSet = mockResultSet(schemaCols, schemaTypes, schemaData, new AtomicInteger(-1));
+
+        String[] tableCols = {"TABLE_NAME"};
+        int[] tableTypes = {Types.VARCHAR};
+        Object[][] tableData = {{tableName.toLowerCase()}};
+        ResultSet tableResultSet = mockResultSet(tableCols, tableTypes, tableData, new AtomicInteger(-1));
+
+        when(preparedStatement.executeQuery()).thenReturn(schemaResultSet).thenReturn(tableResultSet);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * DynamoDB connector now enforces a maximum page size of 100 records per request, preventing potential issues with oversized data retrievals.

* **Chores**
  * Updated dependencies to latest stable versions for improved stability and security.

* **Tests**
  * Expanded test coverage for DataLakeGen2 connector with comprehensive validation of environment properties, metadata handling, record operations, and case resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->