### PR TITLE
Add unit tests in Kafka connector.

### DIFF
--- a/athena-kafka/src/test/java/com/amazonaws/athena/connectors/kafka/KafkaAbstractDeserializerTest.java
+++ b/athena-kafka/src/test/java/com/amazonaws/athena/connectors/kafka/KafkaAbstractDeserializerTest.java
@@ -26,14 +26,11 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
 
-import java.util.Map;
-
 public abstract class KafkaAbstractDeserializerTest
 {
     protected static final ObjectMapper objectMapper = new ObjectMapper();
 
-    protected Schema createSchema(TopicSchema topicSchema) throws Exception
-    {
+    protected Schema createSchema(TopicSchema topicSchema) {
         SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
         topicSchema.getMessage().getFields().forEach(it -> {
             FieldType fieldType = new FieldType(
@@ -54,8 +51,7 @@ public abstract class KafkaAbstractDeserializerTest
         return schemaBuilder.build();
     }
 
-    protected Schema createSchemaForException(TopicSchema topicSchema) throws Exception
-    {
+    protected Schema createSchemaForException(TopicSchema topicSchema) {
         SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
         topicSchema.getMessage().getFields().forEach(it -> {
             FieldType fieldType = new FieldType(

--- a/athena-kafka/src/test/java/com/amazonaws/athena/connectors/kafka/KafkaCompositeHandlerTest.java
+++ b/athena-kafka/src/test/java/com/amazonaws/athena/connectors/kafka/KafkaCompositeHandlerTest.java
@@ -29,7 +29,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 
 
@@ -58,7 +57,7 @@ public class KafkaCompositeHandlerTest {
     private MockedStatic<KafkaUtils> mockedKafkaUtils;
     private MockedStatic<SecretsManagerClient> mockedSecretsManagerClient;
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         mockedSecretsManagerClient = Mockito.mockStatic(SecretsManagerClient.class);
         mockedSecretsManagerClient.when(()-> SecretsManagerClient.create()).thenReturn(secretsManager);
         mockedKafkaUtils = Mockito.mockStatic(KafkaUtils.class);

--- a/athena-kafka/src/test/java/com/amazonaws/athena/connectors/kafka/KafkaMetadataHandlerTest.java
+++ b/athena-kafka/src/test/java/com/amazonaws/athena/connectors/kafka/KafkaMetadataHandlerTest.java
@@ -33,12 +33,14 @@ import software.amazon.awssdk.services.glue.model.GetSchemaRequest;
 import software.amazon.awssdk.services.glue.model.GetSchemaResponse;
 import software.amazon.awssdk.services.glue.model.GetSchemaVersionRequest;
 import software.amazon.awssdk.services.glue.model.GetSchemaVersionResponse;
+import software.amazon.awssdk.services.glue.model.GetRegistryRequest;
+import software.amazon.awssdk.services.glue.model.GetRegistryResponse;
 import software.amazon.awssdk.services.glue.model.ListRegistriesRequest;
 import software.amazon.awssdk.services.glue.model.ListRegistriesResponse;
 import software.amazon.awssdk.services.glue.model.RegistryListItem;
+import software.amazon.awssdk.services.glue.model.SchemaListItem;
 
 import org.apache.kafka.clients.consumer.MockConsumer;
-import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.After;
@@ -52,14 +54,17 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.amazonaws.athena.connectors.kafka.dto.TopicPartitionPiece;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 
 import static org.mockito.Mockito.mock;
@@ -68,6 +73,25 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class KafkaMetadataHandlerTest {
     private static final String QUERY_ID = "queryId";
+    private static final String EARLIEST = "earliest";
+    private static final String TEST_TOPIC = "testTopic";
+    private static final String TEST_TABLE = "testtable";
+    private static final String JSON_FORMAT = "json";
+    private static final String DEFAULT_ARN = "defaultarn";
+    private static final String SCHEMA_ARN = "arn";
+    private static final String DEFAULT_SCHEMA_NAME = "defaultschemaname";
+    private static final String TEST_SCHEMA = "TestSchema";
+    private static final String TEST_REGISTRY = "TestRegistry";
+    private static final String DEFAULT_VERSION_ID = "defaultversionid";
+    private static final String ID = "id";
+    private static final String NAME = "name";
+    private static final Long DEFAULT_LATEST_SCHEMA_VERSION = 123L;
+    private static final String KAFKA_CATALOG = "kafka";
+    private static final String DEFAULT_SCHEMA = "default";
+    private static final String TEST_REGISTRY_DESCRIPTION = "something something {AthenaFederationKafka} something";
+    private static final int DEFAULT_PAGE_SIZE = 10;
+    private static final long START_OFFSET = 0L; 
+    
     private KafkaMetadataHandler kafkaMetadataHandler;
     private BlockAllocator blockAllocator;
     private FederatedIdentity federatedIdentity;
@@ -84,13 +108,20 @@ public class KafkaMetadataHandlerTest {
 
     @Before
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         blockAllocator = new BlockAllocatorImpl();
         federatedIdentity = Mockito.mock(FederatedIdentity.class);
         partitions = Mockito.mock(Block.class);
         partitionCols = Mockito.mock(List.class);
-        constraints = Mockito.mock(Constraints.class);
-        java.util.Map configOptions = com.google.common.collect.ImmutableMap.of(
+        constraints = new Constraints(
+                Collections.emptyMap(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Constraints.DEFAULT_NO_LIMIT,
+                Collections.emptyMap(),
+                null
+        );
+        Map<String, String> configOptions = Map.of(
             "aws.region", "us-west-2",
             "glue_registry_arn", "arn:aws:glue:us-west-2:123456789101:registry/Athena-NEW",
             "auth_type", KafkaUtils.AuthType.SSL.toString(),
@@ -99,15 +130,15 @@ public class KafkaMetadataHandlerTest {
             "certificates_s3_reference", "s3://kafka-connector-test-bucket/kafkafiles/",
             "secrets_manager_secret", "Kafka_afq");
 
-        consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+        consumer = new MockConsumer<>(EARLIEST);
         Map<TopicPartition, Long> partitionsStart = new HashMap<>();
         Map<TopicPartition, Long> partitionsEnd = new HashMap<>();
 
         // max splits per request is 1000. Here we will make 1500 partitions that each have the max records
         // for a single split. we expect 1500 splits to generate, over two requests.
         for (int i = 0; i < 1500; i++) {
-            partitionsStart.put(new TopicPartition("testTopic", i), 0L);
-            partitionsEnd.put(new TopicPartition("testTopic",  i), com.amazonaws.athena.connectors.kafka.KafkaConstants.MAX_RECORDS_IN_SPLIT - 1L); // keep simple and don't have multiple pieces
+            partitionsStart.put(new TopicPartition(TEST_TOPIC, i), START_OFFSET);
+            partitionsEnd.put(new TopicPartition(TEST_TOPIC,  i), com.amazonaws.athena.connectors.kafka.KafkaConstants.MAX_RECORDS_IN_SPLIT - 1L); // keep simple and don't have multiple pieces
         }
         List<PartitionInfo> partitionInfoList = new ArrayList<>(partitionsStart.keySet())
                 .stream()
@@ -115,10 +146,10 @@ public class KafkaMetadataHandlerTest {
                 .collect(Collectors.toList());
         consumer.updateBeginningOffsets(partitionsStart);
         consumer.updateEndOffsets(partitionsEnd);
-        consumer.updatePartitions("testTopic", partitionInfoList);
+        consumer.updatePartitions(TEST_TOPIC, partitionInfoList);
 
         awsGlueClientBuilder = Mockito.mockStatic(GlueClient.class);
-        awsGlueClientBuilder.when(()-> GlueClient.create()).thenReturn(glueClient);
+        awsGlueClientBuilder.when(GlueClient::create).thenReturn(glueClient);
 
         kafkaMetadataHandler = new KafkaMetadataHandler(consumer, configOptions);
     }
@@ -131,15 +162,9 @@ public class KafkaMetadataHandlerTest {
 
     @Test
     public void testDoListSchemaNames() {
-        Mockito.when(glueClient.listRegistries(any(ListRegistriesRequest.class))).thenAnswer(x -> (ListRegistriesResponse.builder()
-                .registries((RegistryListItem.builder())
-                        .registryName("Asdf")
-                        .description("something something {AthenaFederationKafka} something")
-                        .build())
-                .build()
-        ));
+        Mockito.when(glueClient.listRegistries(any(ListRegistriesRequest.class))).thenAnswer(x -> createListRegistriesResponse(null, createRegistryListItem("Asdf", TEST_REGISTRY_DESCRIPTION)));
 
-        ListSchemasRequest listSchemasRequest = new ListSchemasRequest(federatedIdentity, QUERY_ID, "default");
+        ListSchemasRequest listSchemasRequest = new ListSchemasRequest(federatedIdentity, QUERY_ID, DEFAULT_SCHEMA);
         ListSchemasResponse listSchemasResponse = kafkaMetadataHandler.doListSchemaNames(blockAllocator, listSchemasRequest);
 
         assertEquals(new ArrayList(com.google.common.collect.ImmutableList.of("Asdf")), new ArrayList(listSchemasResponse.getSchemas()));
@@ -156,32 +181,22 @@ public class KafkaMetadataHandlerTest {
 
     @Test
     public void testDoGetTable() throws Exception {
-        String arn = "defaultarn", schemaName = "defaultschemaname", schemaVersionId = "defaultversionid";
-        Long latestSchemaVersion = 123L;
-        GetSchemaResponse getSchemaResponse = GetSchemaResponse.builder()
-                .schemaArn(arn)
-                .schemaName(schemaName)
-                .latestSchemaVersion(latestSchemaVersion)
-                .build();
-        GetSchemaVersionResponse getSchemaVersionResponse = GetSchemaVersionResponse.builder()
-                .schemaArn(arn)
-                .schemaVersionId(schemaVersionId)
-                .dataFormat("json")
-                .schemaDefinition("{\n" +
-                        "\t\"topicName\": \"testtable\",\n" +
-                        "\t\"message\": {\n" +
-                        "\t\t\"dataFormat\": \"json\",\n" +
-                        "\t\t\"fields\": [{\n" +
-                        "\t\t\t\"name\": \"intcol\",\n" +
-                        "\t\t\t\"mapping\": \"intcol\",\n" +
-                        "\t\t\t\"type\": \"INTEGER\"\n" +
-                        "\t\t}]\n" +
-                        "\t}\n" +
-                        "}")
-                .build();
+        GetSchemaResponse getSchemaResponse = createGetSchemaResponse(DEFAULT_ARN, DEFAULT_SCHEMA_NAME, DEFAULT_LATEST_SCHEMA_VERSION);
+        GetSchemaVersionResponse getSchemaVersionResponse = createGetSchemaVersionResponse(DEFAULT_ARN, DEFAULT_VERSION_ID, JSON_FORMAT, "{\n" +
+                "\t\"topicName\": \"" + TEST_TABLE + "\",\n" +
+                "\t\"message\": {\n" +
+                "\t\t\"dataFormat\": \"" + JSON_FORMAT + "\",\n" +
+                "\t\t\"fields\": [{\n" +
+                "\t\t\t\"name\": \"intcol\",\n" +
+                "\t\t\t\"mapping\": \"intcol\",\n" +
+                "\t\t\t\"type\": \"INTEGER\"\n" +
+                "\t\t}]\n" +
+                "\t}\n" +
+                "}");
+        
         Mockito.when(glueClient.getSchema(any(GetSchemaRequest.class))).thenReturn(getSchemaResponse);
         Mockito.when(glueClient.getSchemaVersion(any(GetSchemaVersionRequest.class))).thenReturn(getSchemaVersionResponse);
-        GetTableRequest getTableRequest = new GetTableRequest(federatedIdentity, QUERY_ID, "kafka", new TableName("default", "testtable"), Collections.emptyMap());
+        GetTableRequest getTableRequest = createGetTableRequest(DEFAULT_SCHEMA, TEST_TABLE);
         GetTableResponse getTableResponse = kafkaMetadataHandler.doGetTable(blockAllocator, getTableRequest);
         assertEquals(1, getTableResponse.getSchema().getFields().size());
     }
@@ -189,42 +204,31 @@ public class KafkaMetadataHandlerTest {
     @Test
     public void testDoGetSplits() throws Exception
     {
-        String arn = "defaultarn", schemaName = "defaultschemaname", schemaVersionId = "defaultversionid";
-        Long latestSchemaVersion = 123L;
-        GetSchemaResponse getSchemaResponse = GetSchemaResponse.builder()
-                .schemaArn(arn)
-                .schemaName(schemaName)
-                .latestSchemaVersion(latestSchemaVersion)
-                .build();
-        GetSchemaVersionResponse getSchemaVersionResponse = GetSchemaVersionResponse.builder()
-                .schemaArn(arn)
-                .schemaVersionId(schemaVersionId)
-                .dataFormat("json")
-                .schemaDefinition("{\n" +
-                        "\t\"topicName\": \"testTopic\",\n" +
-                        "\t\"message\": {\n" +
-                        "\t\t\"dataFormat\": \"json\",\n" +
-                        "\t\t\"fields\": [{\n" +
-                        "\t\t\t\"name\": \"intcol\",\n" +
-                        "\t\t\t\"mapping\": \"intcol\",\n" +
-                        "\t\t\t\"type\": \"INTEGER\"\n" +
-                        "\t\t}]\n" +
-                        "\t}\n" +
-                        "}")
-                .build();
-
+        GetSchemaResponse getSchemaResponse = createGetSchemaResponse(DEFAULT_ARN, DEFAULT_SCHEMA_NAME, DEFAULT_LATEST_SCHEMA_VERSION);
+        GetSchemaVersionResponse getSchemaVersionResponse = createGetSchemaVersionResponse(DEFAULT_ARN, DEFAULT_VERSION_ID, JSON_FORMAT, "{\n" +
+                "\t\"topicName\": \"testTopic\",\n" +
+                "\t\"message\": {\n" +
+                "\t\t\"dataFormat\": \"json\",\n" +
+                "\t\t\"fields\": [{\n" +
+                "\t\t\t\"name\": \"intcol\",\n" +
+                "\t\t\t\"mapping\": \"intcol\",\n" +
+                "\t\t\t\"type\": \"INTEGER\"\n" +
+                "\t\t}]\n" +
+                "\t}\n" +
+                "}");
+        
         Mockito.when(glueClient.getSchema(any(GetSchemaRequest.class))).thenReturn(getSchemaResponse);
         Mockito.when(glueClient.getSchemaVersion(any(GetSchemaVersionRequest.class))).thenReturn(getSchemaVersionResponse);
 
         GetSplitsRequest request = new GetSplitsRequest(
                 federatedIdentity,
                 QUERY_ID,
-                "kafka",
-                new TableName("default", "testTopic"),
+                KAFKA_CATALOG,
+                new TableName(DEFAULT_SCHEMA, TEST_TOPIC),
                 Mockito.mock(Block.class),
                 new ArrayList<>(),
                 Mockito.mock(Constraints.class),
-                null 
+                null
         );
 
         GetSplitsResponse response = kafkaMetadataHandler.doGetSplits(blockAllocator, request);
@@ -233,8 +237,8 @@ public class KafkaMetadataHandlerTest {
         request = new GetSplitsRequest(
                 federatedIdentity,
                 QUERY_ID,
-                "kafka",
-                new TableName("default", "testTopic"),
+                KAFKA_CATALOG,
+                new TableName(DEFAULT_SCHEMA, TEST_TOPIC),
                 Mockito.mock(Block.class),
                 new ArrayList<>(),
                 Mockito.mock(Constraints.class),
@@ -243,5 +247,481 @@ public class KafkaMetadataHandlerTest {
         response = kafkaMetadataHandler.doGetSplits(blockAllocator, request);
         assertEquals(500, response.getSplits().size());
         assertNull(response.getContinuationToken());
+    }
+
+    @Test
+    public void doGetTable_withCaseInsensitiveResolution_returnsResolvedSchema() throws Exception {
+        Mockito.when(glueClient.getSchema(any(GetSchemaRequest.class)))
+                .thenThrow(new RuntimeException("Schema not found"))
+                .thenReturn(createGetSchemaResponse(SCHEMA_ARN, TEST_SCHEMA, 1L));
+
+        ListRegistriesResponse registriesResponse = createListRegistriesResponse(null, createRegistryListItem(TEST_REGISTRY, TEST_REGISTRY_DESCRIPTION));
+        Mockito.when(glueClient.listRegistries(any(ListRegistriesRequest.class)))
+                .thenReturn(registriesResponse);
+
+        software.amazon.awssdk.services.glue.model.ListSchemasResponse schemasResponse = software.amazon.awssdk.services.glue.model.ListSchemasResponse.builder()
+                .schemas(SchemaListItem.builder().schemaName(TEST_SCHEMA).build())
+                .build();
+        Mockito.when(glueClient.listSchemas(any(software.amazon.awssdk.services.glue.model.ListSchemasRequest.class)))
+                .thenReturn(schemasResponse);
+
+        GetSchemaVersionResponse schemaVersionResponse = createGetSchemaVersionResponse(SCHEMA_ARN, "1", JSON_FORMAT, "{\n" +
+                "\t\"topicName\": \"testtable\",\n" +
+                "\t\"message\": {\n" +
+                "\t\t\"dataFormat\": \"json\",\n" +
+                "\t\t\"fields\": [{\n" +
+                "\t\t\t\"name\": \"col1\",\n" +
+                "\t\t\t\"mapping\": \"col1\",\n" +
+                "\t\t\t\"type\": \"STRING\"\n" +
+                "\t\t}]\n" +
+                "\t}\n" +
+                "}");
+        Mockito.when(glueClient.getSchemaVersion(any(GetSchemaVersionRequest.class)))
+                .thenReturn(schemaVersionResponse);
+
+        GetTableRequest getTableRequest = createGetTableRequest(TEST_REGISTRY, TEST_SCHEMA);
+        GetTableResponse getTableResponse = kafkaMetadataHandler.doGetTable(blockAllocator, getTableRequest);
+
+        assertEquals(1, getTableResponse.getSchema().getFields().size());
+        assertEquals("col1", getTableResponse.getSchema().getFields().get(0).getName());
+        assertEquals(TEST_REGISTRY, getTableResponse.getTableName().getSchemaName());
+        assertEquals(TEST_SCHEMA, getTableResponse.getTableName().getTableName());
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void doGetTable_withInvalidSchema_throwsRuntimeException() throws Exception {
+        GetSchemaResponse getSchemaResponse = createGetSchemaResponse(SCHEMA_ARN, "invalid", 1L);
+        GetSchemaVersionResponse getSchemaVersionResponse = createGetSchemaVersionResponse(SCHEMA_ARN, "1", JSON_FORMAT, "invalid json");
+
+        Mockito.when(glueClient.getSchema(any(GetSchemaRequest.class))).thenReturn(getSchemaResponse);
+        Mockito.when(glueClient.getSchemaVersion(any(GetSchemaVersionRequest.class))).thenReturn(getSchemaVersionResponse);
+
+        GetTableRequest getTableRequest = createGetTableRequest(DEFAULT_SCHEMA, "invalid");
+        kafkaMetadataHandler.doGetTable(blockAllocator, getTableRequest);
+    }
+
+    @Test
+    public void pieceTopicPartition_withSinglePiece_returnsSinglePiece() {
+        long startOffset = START_OFFSET;
+        long endOffset = 5000L; // Less than MAX_RECORDS_IN_SPLIT (10000)
+
+        List<TopicPartitionPiece> pieces = kafkaMetadataHandler.pieceTopicPartition(startOffset, endOffset);
+
+        assertEquals(1, pieces.size());
+        assertEquals(startOffset, pieces.get(0).startOffset);
+        assertEquals(endOffset, pieces.get(0).endOffset);
+    }
+
+    @Test
+    public void pieceTopicPartition_withMultiplePieces_returnsMultiplePieces() {
+        long endOffset = 25000L;
+
+        List<TopicPartitionPiece> pieces = kafkaMetadataHandler.pieceTopicPartition(START_OFFSET, endOffset);
+
+        assertEquals(3, pieces.size());
+
+        assertEquals(START_OFFSET, pieces.get(0).startOffset);
+        assertEquals(10000L, pieces.get(0).endOffset);
+
+        assertEquals(10001L, pieces.get(1).startOffset);
+        assertEquals(20001L, pieces.get(1).endOffset);
+
+        assertEquals(20002L, pieces.get(2).startOffset);
+        assertEquals(25000L, pieces.get(2).endOffset);
+    }
+
+    @Test
+    public void pieceTopicPartition_withNonZeroStart_returnsCorrectPieces() {
+        long startOffset = 5000L;
+        long endOffset = 35000L;
+
+        List<TopicPartitionPiece> pieces = kafkaMetadataHandler.pieceTopicPartition(startOffset, endOffset);
+
+        assertEquals(3, pieces.size());
+
+        assertEquals(5000L, pieces.get(0).startOffset);
+        assertEquals(15000L, pieces.get(0).endOffset);
+
+        assertEquals(15001L, pieces.get(1).startOffset);
+        assertEquals(25001L, pieces.get(1).endOffset);
+
+        assertEquals(25002L, pieces.get(2).startOffset);
+        assertEquals(35000L, pieces.get(2).endOffset);
+    }
+
+    @Test
+    public void pieceTopicPartition_withMaxRecords_returnsCorrectPieces() {
+        long endOffset = 10000L;
+
+        List<TopicPartitionPiece> pieces = kafkaMetadataHandler.pieceTopicPartition(START_OFFSET, endOffset);
+
+        assertEquals(1, pieces.size());
+        assertEquals(START_OFFSET, pieces.get(0).startOffset);
+        assertEquals(10000L, pieces.get(0).endOffset);
+    }
+
+    @Test
+    public void pieceTopicPartition_withLargePartition_returnsMultiplePieces() {
+        long endOffset = 1_000_000L;
+
+        List<TopicPartitionPiece> pieces = kafkaMetadataHandler.pieceTopicPartition(START_OFFSET, endOffset);
+
+        assertEquals(100, pieces.size());
+
+        assertEquals(START_OFFSET, pieces.get(0).startOffset);
+        assertEquals(10000L, pieces.get(0).endOffset);
+
+        assertEquals(500050L, pieces.get(50).startOffset);
+        assertEquals(510050L, pieces.get(50).endOffset);
+
+        assertEquals(990099L, pieces.get(99).startOffset);
+        assertEquals(1000000L, pieces.get(99).endOffset);
+    }
+
+    @Test
+    public void doGetTable_withAvroFormat_returnsAvroSchema() throws Exception {
+        GetSchemaResponse getSchemaResponse = createGetSchemaResponse("arn:aws:glue:us-west-2:123456789101:schema/TestRegistry/avroSchema", "avroSchema", 1L);
+
+        String avroSchemaDefinition = "{\n" +
+                "  \"name\": \"TestRecord\",\n" +
+                "  \"type\": \"record\",\n" +
+                "  \"fields\": [\n" +
+                "    {\n" +
+                "      \"name\": \"id\",\n" +
+                "      \"type\": \"int\",\n" +
+                "      \"formatHint\": \"%d\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"name\": \"name\",\n" +
+                "      \"type\": \"string\",\n" +
+                "      \"formatHint\": \"%s\"\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}";
+
+        GetSchemaVersionResponse getSchemaVersionResponse = createGetSchemaVersionResponse("arn:aws:glue:us-west-2:123456789101:schema/TestRegistry/avroSchema", "1", "AVRO", avroSchemaDefinition);
+
+        Mockito.when(glueClient.getSchema(any(GetSchemaRequest.class))).thenReturn(getSchemaResponse);
+        Mockito.when(glueClient.getSchemaVersion(any(GetSchemaVersionRequest.class))).thenReturn(getSchemaVersionResponse);
+
+        GetTableRequest getTableRequest = createGetTableRequest(TEST_REGISTRY, "avroSchema");
+
+        GetTableResponse getTableResponse = kafkaMetadataHandler.doGetTable(blockAllocator, getTableRequest);
+
+        assertEquals(2, getTableResponse.getSchema().getFields().size());
+        assertEquals(ID, getTableResponse.getSchema().getFields().get(0).getName());
+        assertEquals(NAME, getTableResponse.getSchema().getFields().get(1).getName());
+
+        assertEquals(ID, getTableResponse.getSchema().getFields().get(0).getMetadata().get(NAME));
+        assertEquals("int", getTableResponse.getSchema().getFields().get(0).getMetadata().get("type"));
+        assertEquals("%d", getTableResponse.getSchema().getFields().get(0).getMetadata().get("formatHint"));
+
+        assertEquals(NAME, getTableResponse.getSchema().getFields().get(1).getMetadata().get(NAME));
+        assertEquals("string", getTableResponse.getSchema().getFields().get(1).getMetadata().get("type"));
+        assertEquals("%s", getTableResponse.getSchema().getFields().get(1).getMetadata().get("formatHint"));
+
+        assertEquals("avro", getTableResponse.getSchema().getCustomMetadata().get("dataFormat"));
+        assertEquals(TEST_REGISTRY, getTableResponse.getSchema().getCustomMetadata().get("glueRegistryName"));
+        assertEquals("avroSchema", getTableResponse.getSchema().getCustomMetadata().get("glueSchemaName"));
+    }
+
+    @Test
+    public void doGetTable_withProtobufFormat_returnsProtobufSchema() throws Exception {
+        GetSchemaResponse getSchemaResponse = createGetSchemaResponse("arn:aws:glue:us-west-2:123456789101:schema/TestRegistry/protobufSchema", "protobufSchema", 1L);
+
+        String protobufSchemaDefinition = "syntax = \"proto3\";\n" +
+                "message TestMessage {\n" +
+                "  int32 id = 1;\n" +
+                "  string name = 2;\n" +
+                "  double price = 3;\n" +
+                "}";
+
+        GetSchemaVersionResponse getSchemaVersionResponse = createGetSchemaVersionResponse("arn:aws:glue:us-west-2:123456789101:schema/TestRegistry/protobufSchema", "1", "PROTOBUF", protobufSchemaDefinition);
+
+        Mockito.when(glueClient.getSchema(any(GetSchemaRequest.class))).thenReturn(getSchemaResponse);
+        Mockito.when(glueClient.getSchemaVersion(any(GetSchemaVersionRequest.class))).thenReturn(getSchemaVersionResponse);
+
+        GetTableRequest getTableRequest = createGetTableRequest(TEST_REGISTRY, "protobufSchema");
+
+        GetTableResponse getTableResponse = kafkaMetadataHandler.doGetTable(blockAllocator, getTableRequest);
+
+        assertEquals(3, getTableResponse.getSchema().getFields().size());
+        assertEquals(ID, getTableResponse.getSchema().getFields().get(0).getName());
+        assertEquals(NAME, getTableResponse.getSchema().getFields().get(1).getName());
+        assertEquals("price", getTableResponse.getSchema().getFields().get(2).getName());
+
+        assertEquals("protobuf", getTableResponse.getSchema().getCustomMetadata().get("dataFormat"));
+        assertEquals(TEST_REGISTRY, getTableResponse.getSchema().getCustomMetadata().get("glueRegistryName"));
+        assertEquals("protobufSchema", getTableResponse.getSchema().getCustomMetadata().get("glueSchemaName"));
+    }
+
+    @Test
+    public void doListTables_withUnlimitedPageSize_returnsAllTables() {
+        ListRegistriesResponse registriesResponse = createListRegistriesResponse(null, createRegistryListItem(TEST_REGISTRY, TEST_REGISTRY_DESCRIPTION));
+        Mockito.when(glueClient.listRegistries(any(ListRegistriesRequest.class)))
+                .thenReturn(registriesResponse);
+
+        List<String> schemaItems = new ArrayList<>();
+        for (int i = 1; i <= 50; i++) {
+            schemaItems.add("schema" + i);
+        }
+
+        List<SchemaListItem> schemas = schemaItems.stream()
+                .map(name -> SchemaListItem.builder().schemaName(name).build())
+                .collect(Collectors.toList());
+        software.amazon.awssdk.services.glue.model.ListSchemasResponse schemasResponse = software.amazon.awssdk.services.glue.model.ListSchemasResponse.builder()
+                .schemas(schemas)
+                .build();
+        Mockito.when(glueClient.listSchemas(any(software.amazon.awssdk.services.glue.model.ListSchemasRequest.class)))
+                .thenReturn(schemasResponse);
+
+        ListTablesRequest listTablesRequest = new ListTablesRequest(
+                federatedIdentity,
+                QUERY_ID,
+                KAFKA_CATALOG,
+                TEST_REGISTRY,
+                null,
+                ListTablesRequest.UNLIMITED_PAGE_SIZE_VALUE
+        );
+
+        ListTablesResponse response = kafkaMetadataHandler.doListTables(blockAllocator, listTablesRequest);
+
+        assertEquals(50, response.getTables().size());
+        assertNull(response.getNextToken());
+        
+        for (int i = 1; i <= 50; i++) {
+            final int schemaIndex = i;
+            boolean found = response.getTables().stream()
+                    .anyMatch(table -> table.getTableName().equals("schema" + schemaIndex));
+            assertTrue("Schema" + schemaIndex + " should be present", found);
+        }
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void doListTables_whenExceedsMaxResults_throwsRuntimeException() {
+        ListRegistriesResponse registriesResponse = createListRegistriesResponse(null, createRegistryListItem(TEST_REGISTRY, TEST_REGISTRY_DESCRIPTION));
+        Mockito.when(glueClient.listRegistries(any(ListRegistriesRequest.class)))
+                .thenReturn(registriesResponse);
+
+        List<String> largeSchemaList = new ArrayList<>();
+        for (int i = 1; i <= 100001; i++) {
+            largeSchemaList.add("schema" + i);
+        }
+
+        List<SchemaListItem> largeSchemas = largeSchemaList.stream()
+                .map(name -> SchemaListItem.builder().schemaName(name).build())
+                .collect(Collectors.toList());
+        software.amazon.awssdk.services.glue.model.ListSchemasResponse largeResponse = software.amazon.awssdk.services.glue.model.ListSchemasResponse.builder()
+                .schemas(largeSchemas)
+                .build();
+
+        Mockito.when(glueClient.listSchemas(any(software.amazon.awssdk.services.glue.model.ListSchemasRequest.class)))
+                .thenReturn(largeResponse);
+
+        ListTablesRequest listTablesRequest = new ListTablesRequest(
+                federatedIdentity,
+                QUERY_ID,
+                KAFKA_CATALOG,
+                TEST_REGISTRY,
+                null,
+                ListTablesRequest.UNLIMITED_PAGE_SIZE_VALUE
+        );
+
+        kafkaMetadataHandler.doListTables(blockAllocator, listTablesRequest);
+    }
+
+    @Test
+    public void doListSchemaNames_withPagination_returnsPaginatedResults() {
+        ListRegistriesResponse firstPageResponse = createListRegistriesResponse("token1", createRegistryListItem("Registry1", TEST_REGISTRY_DESCRIPTION));
+
+        ListRegistriesResponse secondPageResponse = createListRegistriesResponse(null, createRegistryListItem("Registry2", TEST_REGISTRY_DESCRIPTION));
+
+        Mockito.when(glueClient.listRegistries(any(ListRegistriesRequest.class)))
+                .thenReturn(firstPageResponse)
+                .thenReturn(secondPageResponse);
+
+        ListSchemasRequest listSchemasRequest = new ListSchemasRequest(federatedIdentity, QUERY_ID, DEFAULT_SCHEMA);
+        ListSchemasResponse listSchemasResponse = kafkaMetadataHandler.doListSchemaNames(blockAllocator, listSchemasRequest);
+
+        List<String> expectedRegistries = Arrays.asList("Registry1", "Registry2");
+        assertEquals(new ArrayList<>(expectedRegistries), new ArrayList<>(listSchemasResponse.getSchemas()));
+    }
+
+    @Test
+    public void doListSchemaNames_withNullDescription_returnsSchemas() {
+        ListRegistriesResponse response = createListRegistriesResponse(null,
+                createRegistryListItem("Registry1", null),
+                createRegistryListItem("Registry2", TEST_REGISTRY_DESCRIPTION));
+
+        Mockito.when(glueClient.listRegistries(any(ListRegistriesRequest.class)))
+                .thenReturn(response);
+
+        ListSchemasRequest listSchemasRequest = new ListSchemasRequest(federatedIdentity, QUERY_ID, DEFAULT_SCHEMA);
+        ListSchemasResponse listSchemasResponse = kafkaMetadataHandler.doListSchemaNames(blockAllocator, listSchemasRequest);
+
+        List<String> expectedRegistries = List.of("Registry2");
+        assertEquals(new ArrayList<>(expectedRegistries), new ArrayList<>(listSchemasResponse.getSchemas()));
+    }
+
+    @Test
+    public void doListTables_withEmptyDescription_returnsTables() {
+        GetRegistryResponse getRegistryResponse = GetRegistryResponse.builder()
+                .registryName(TEST_REGISTRY)
+                .description("")
+                .build();
+
+        Mockito.when(glueClient.getRegistry(any(GetRegistryRequest.class)))
+                .thenReturn(getRegistryResponse);
+
+        ListRegistriesResponse registriesResponse = createListRegistriesResponse(null, createRegistryListItem(TEST_REGISTRY, TEST_REGISTRY_DESCRIPTION));
+        Mockito.when(glueClient.listRegistries(any(ListRegistriesRequest.class)))
+                .thenReturn(registriesResponse);
+
+        software.amazon.awssdk.services.glue.model.ListSchemasResponse schemasResponse = software.amazon.awssdk.services.glue.model.ListSchemasResponse.builder()
+                .schemas(SchemaListItem.builder().schemaName(TEST_SCHEMA).build())
+                .build();
+        Mockito.when(glueClient.listSchemas(any(software.amazon.awssdk.services.glue.model.ListSchemasRequest.class)))
+                .thenReturn(schemasResponse);
+
+        ListTablesRequest listTablesRequest = new ListTablesRequest(
+                federatedIdentity,
+                QUERY_ID,
+                KAFKA_CATALOG,
+                TEST_REGISTRY,
+                TEST_SCHEMA,
+                DEFAULT_PAGE_SIZE
+        );
+
+        ListTablesResponse response = kafkaMetadataHandler.doListTables(blockAllocator, listTablesRequest);
+        List<TableName> tables = new ArrayList<>(response.getTables());
+        assertEquals(1, tables.size());
+        assertEquals(TEST_REGISTRY, tables.get(0).getSchemaName());
+        assertEquals(TEST_SCHEMA, tables.get(0).getTableName());
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void doGetTable_whenGlueThrowsException_throwsRuntimeException() throws Exception {
+        Mockito.when(glueClient.getSchema(any(GetSchemaRequest.class)))
+                .thenThrow(new RuntimeException("Glue service unavailable"));
+
+        GetTableRequest getTableRequest = new GetTableRequest(
+                federatedIdentity,
+                QUERY_ID,
+                KAFKA_CATALOG,
+                new TableName(TEST_REGISTRY, TEST_SCHEMA),
+                Collections.emptyMap()
+        );
+
+        kafkaMetadataHandler.doGetTable(blockAllocator, getTableRequest);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void doListTables_whenGlueThrowsException_throwsRuntimeException() {
+        Mockito.when(glueClient.listRegistries(any(ListRegistriesRequest.class)))
+                .thenThrow(new RuntimeException("Glue service unavailable"));
+
+        ListTablesRequest listTablesRequest = new ListTablesRequest(
+                federatedIdentity,
+                QUERY_ID,
+                KAFKA_CATALOG,
+                TEST_REGISTRY,
+                null,
+                DEFAULT_PAGE_SIZE
+        );
+
+        kafkaMetadataHandler.doListTables(blockAllocator, listTablesRequest);
+    }
+
+    @Test
+    public void doGetTable_withEmptyAvroFields_returnsEmptySchema() throws Exception {
+        // Mock Glue responses for AVRO format with empty fields
+        GetSchemaResponse getSchemaResponse = createGetSchemaResponse("arn:aws:glue:us-west-2:123456789101:schema/TestRegistry/emptyAvroSchema", "emptyAvroSchema", 1L);
+
+        // Create AVRO schema definition with empty fields array
+        String emptyAvroSchemaDefinition = "{\n" +
+                "  \"name\": \"EmptyRecord\",\n" +
+                "  \"type\": \"record\",\n" +
+                "  \"fields\": []\n" +
+                "}";
+
+        GetSchemaVersionResponse getSchemaVersionResponse = createGetSchemaVersionResponse("arn:aws:glue:us-west-2:123456789101:schema/TestRegistry/emptyAvroSchema", "1", "AVRO", emptyAvroSchemaDefinition);
+
+        Mockito.when(glueClient.getSchema(any(GetSchemaRequest.class))).thenReturn(getSchemaResponse);
+        Mockito.when(glueClient.getSchemaVersion(any(GetSchemaVersionRequest.class))).thenReturn(getSchemaVersionResponse);
+
+        GetTableRequest getTableRequest = createGetTableRequest(TEST_REGISTRY, "emptyAvroSchema");
+
+        GetTableResponse getTableResponse = kafkaMetadataHandler.doGetTable(blockAllocator, getTableRequest);
+
+        // Verify schema has no fields but proper metadata
+        assertEquals(0, getTableResponse.getSchema().getFields().size());
+        assertEquals("avro", getTableResponse.getSchema().getCustomMetadata().get("dataFormat"));
+        assertEquals(TEST_REGISTRY, getTableResponse.getSchema().getCustomMetadata().get("glueRegistryName"));
+        assertEquals("emptyAvroSchema", getTableResponse.getSchema().getCustomMetadata().get("glueSchemaName"));
+    }
+
+    @Test
+    public void doGetTable_withEmptyProtobufFields_returnsEmptySchema() throws Exception {
+        GetSchemaResponse getSchemaResponse = createGetSchemaResponse("arn:aws:glue:us-west-2:123456789101:schema/TestRegistry/emptyProtobufSchema", "emptyProtobufSchema", 1L);
+
+        // Create PROTOBUF schema definition with no fields
+        String emptyProtobufSchemaDefinition = "syntax = \"proto3\";\n" +
+                "message EmptyMessage {\n" +
+                "}";
+
+        GetSchemaVersionResponse getSchemaVersionResponse = createGetSchemaVersionResponse("arn:aws:glue:us-west-2:123456789101:schema/TestRegistry/emptyProtobufSchema", "1", "PROTOBUF", emptyProtobufSchemaDefinition);
+
+        Mockito.when(glueClient.getSchema(any(GetSchemaRequest.class))).thenReturn(getSchemaResponse);
+        Mockito.when(glueClient.getSchemaVersion(any(GetSchemaVersionRequest.class))).thenReturn(getSchemaVersionResponse);
+
+        GetTableRequest getTableRequest = createGetTableRequest(TEST_REGISTRY, "emptyProtobufSchema");
+
+        GetTableResponse getTableResponse = kafkaMetadataHandler.doGetTable(blockAllocator, getTableRequest);
+
+        assertEquals(0, getTableResponse.getSchema().getFields().size());
+        assertEquals("protobuf", getTableResponse.getSchema().getCustomMetadata().get("dataFormat"));
+        assertEquals(TEST_REGISTRY, getTableResponse.getSchema().getCustomMetadata().get("glueRegistryName"));
+        assertEquals("emptyProtobufSchema", getTableResponse.getSchema().getCustomMetadata().get("glueSchemaName"));
+    }
+    
+    private RegistryListItem createRegistryListItem(String registryName, String description) {
+        return RegistryListItem.builder()
+                .registryName(registryName)
+                .description(description)
+                .build();
+    }
+
+    private ListRegistriesResponse createListRegistriesResponse(String nextToken, RegistryListItem... items) {
+        return ListRegistriesResponse.builder()
+                .registries(items)
+                .nextToken(nextToken)
+                .build();
+    }
+
+    private GetSchemaResponse createGetSchemaResponse(String schemaArn, String schemaName, Long latestSchemaVersion) {
+        return GetSchemaResponse.builder()
+                .schemaArn(schemaArn)
+                .schemaName(schemaName)
+                .latestSchemaVersion(latestSchemaVersion)
+                .build();
+    }
+
+    private GetSchemaVersionResponse createGetSchemaVersionResponse(String schemaArn, String schemaVersionId, String dataFormat, String schemaDefinition) {
+        return GetSchemaVersionResponse.builder()
+                .schemaArn(schemaArn)
+                .schemaVersionId(schemaVersionId)
+                .dataFormat(dataFormat)
+                .schemaDefinition(schemaDefinition)
+                .build();
+    }
+
+    private GetTableRequest createGetTableRequest(String schemaName, String tableName) {
+        return new GetTableRequest(
+                federatedIdentity,
+                QUERY_ID,
+                KAFKA_CATALOG,
+                new TableName(schemaName, tableName),
+                Collections.emptyMap()
+        );
     }
 }

--- a/athena-kafka/src/test/java/com/amazonaws/athena/connectors/kafka/KafkaUtilsTest.java
+++ b/athena-kafka/src/test/java/com/amazonaws/athena/connectors/kafka/KafkaUtilsTest.java
@@ -21,7 +21,6 @@ package com.amazonaws.athena.connectors.kafka;
 
 import com.amazonaws.athena.connectors.kafka.dto.SplitParameters;
 import com.amazonaws.athena.connectors.kafka.dto.TopicResultSet;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -31,7 +30,6 @@ import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -62,10 +60,29 @@ import static com.amazonaws.athena.connectors.kafka.KafkaUtils.*;
 import static org.junit.Assert.*;
 import static java.util.Arrays.asList;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.nullable;
 
 @RunWith(MockitoJUnitRunner.class)
 public class KafkaUtilsTest {
+    private static final String TEST_USERNAME = "admin";
+    private static final String TEST_PASSWORD = "test";
+    private static final String TEST_KEYSTORE_PASSWORD = "keypass";
+    private static final String TEST_TRUSTSTORE_PASSWORD = "trustpass";
+    private static final String TEST_SSL_KEY_PASSWORD = "sslpass";
+    private static final String DIFFERENT_USERNAME = "testuser";
+    private static final String DIFFERENT_PASSWORD = "testpass";
+    private static final String SECURITY_PROTOCOL = "security.protocol";
+    private static final String SASL_MECHANISM = "sasl.mechanism";
+    private static final String SASL_JAAS_CONFIG = "sasl.jaas.config";
+    private static final String SSL_TRUSTSTORE_LOCATION = "ssl.truststore.location";
+    private static final String SSL_TRUSTSTORE_PASSWORD = "ssl.truststore.password";
+    private static final String SASL_PLAINTEXT = "SASL_PLAINTEXT";
+    private static final String SASL_SSL = "SASL_SSL";
+    private static final String SCRAM_SHA_512 = "SCRAM-SHA-512";
+    private static final String PLAIN = "PLAIN";
+
+    private static final String SCRAM_JAAS_TEMPLATE = "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"%s\" password=\"%s\";";
+    private static final String PLAIN_JAAS_TEMPLATE = "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"%s\" password=\"%s\";";
+
     @Mock
     FileWriter fileWriter;
 
@@ -107,7 +124,7 @@ public class KafkaUtilsTest {
 
 
     @Before
-    public void init() throws Exception {
+    public void init() {
         System.setProperty("aws.region", "us-west-2");
         System.setProperty("aws.accessKeyId", "xxyyyioyuu");
         System.setProperty("aws.secretKey", "vamsajdsjkl");
@@ -115,14 +132,14 @@ public class KafkaUtilsTest {
         mockedSecretsManagerClient = Mockito.mockStatic(SecretsManagerClient.class);
         mockedSecretsManagerClient.when(()-> SecretsManagerClient.create()).thenReturn(awsSecretsManager);
 
-        String creds = "{\"username\":\"admin\",\"password\":\"test\",\"keystore_password\":\"keypass\",\"truststore_password\":\"trustpass\",\"ssl_key_password\":\"sslpass\"}";
+        String creds = createCredentialsJson(TEST_USERNAME, TEST_PASSWORD);
 
         Map<String, Object> map = new HashMap<>();
-        map.put("username", "admin");
-        map.put("password", "test");
-        map.put("keystore_password", "keypass");
-        map.put("truststore_password", "trustpass");
-        map.put("ssl_key_password", "sslpass");
+        map.put("username", TEST_USERNAME);
+        map.put("password", TEST_PASSWORD);
+        map.put("keystore_password", TEST_KEYSTORE_PASSWORD);
+        map.put("truststore_password", TEST_TRUSTSTORE_PASSWORD);
+        map.put("ssl_key_password", TEST_SSL_KEY_PASSWORD);
 
         Mockito.when(secretValueResponse.secretString()).thenReturn(creds);
         Mockito.when(awsSecretsManager.getSecretValue(Mockito.isA(GetSecretValueRequest.class))).thenReturn(secretValueResponse);
@@ -147,15 +164,16 @@ public class KafkaUtilsTest {
         mockedS3ClientBuilder.close();
         mockedSecretsManagerClient.close();
     }
+
     @Test
     public void testGetScramAuthKafkaProperties() throws Exception {
         java.util.HashMap testConfigOptions = new java.util.HashMap(configOptions);
         testConfigOptions.put("auth_type", KafkaUtils.AuthType.SASL_SSL_SCRAM_SHA512.toString());
-        String sasljaasconfig = "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"admin\" password=\"test\";";
+        String sasljaasconfig = formatJaasConfig(true, TEST_USERNAME, TEST_PASSWORD);
         Properties properties = getKafkaProperties(testConfigOptions);
-        assertEquals("SASL_SSL", properties.get("security.protocol"));
-        assertEquals("SCRAM-SHA-512", properties.get("sasl.mechanism"));
-        assertEquals(sasljaasconfig, properties.get("sasl.jaas.config"));
+        assertEquals(SASL_SSL, properties.get(SECURITY_PROTOCOL));
+        assertEquals(SCRAM_SHA_512, properties.get(SASL_MECHANISM));
+        assertEquals(sasljaasconfig, properties.get(SASL_JAAS_CONFIG));
     }
 
     @Test
@@ -163,10 +181,10 @@ public class KafkaUtilsTest {
         java.util.HashMap testConfigOptions = new java.util.HashMap(configOptions);
         testConfigOptions.put("auth_type", KafkaUtils.AuthType.SSL.toString());
         Properties properties = getKafkaProperties(testConfigOptions);
-        assertEquals("SSL", properties.get("security.protocol"));
-        assertEquals("keypass", properties.get("ssl.keystore.password"));
-        assertEquals("sslpass", properties.get("ssl.key.password"));
-        assertEquals("trustpass", properties.get("ssl.truststore.password"));
+        assertEquals("SSL", properties.get(SECURITY_PROTOCOL));
+        assertEquals(TEST_KEYSTORE_PASSWORD, properties.get("ssl.keystore.password"));
+        assertEquals(TEST_SSL_KEY_PASSWORD, properties.get("ssl.key.password"));
+        assertEquals(TEST_TRUSTSTORE_PASSWORD, properties.get(SSL_TRUSTSTORE_PASSWORD));
     }
 
     @Test
@@ -228,5 +246,116 @@ public class KafkaUtilsTest {
     @Test(expected = IllegalArgumentException.class)
     public void testGetKafkaPropertiesForIllegalArgumentException() throws Exception {
         getKafkaProperties(com.google.common.collect.ImmutableMap.of());
+    }
+
+    @Test
+    public void setAuthKafkaProperties_withScramPlainText_setsScramProperties() throws Exception {
+        Map<String, String> testConfigOptions = createTestConfigOptions(KafkaUtils.AuthType.SASL_PLAINTEXT_SCRAM_SHA512.toString());
+        Properties properties = getKafkaProperties(testConfigOptions);
+
+        verifyCommonSaslProperties(properties, SASL_PLAINTEXT, SCRAM_SHA_512, formatJaasConfig(true, TEST_USERNAME, TEST_PASSWORD));
+        verifyNoSslProperties(properties);
+    }
+
+    @Test
+    public void setAuthKafkaProperties_withSaslPlain_setsSaslProperties() throws Exception {
+        Map<String, String> testConfigOptions = createTestConfigOptions(KafkaUtils.AuthType.SASL_PLAINTEXT_PLAIN.toString());
+        Properties properties = getKafkaProperties(testConfigOptions);
+
+        verifyCommonSaslProperties(properties, SASL_PLAINTEXT, PLAIN, formatJaasConfig(false, TEST_USERNAME, TEST_PASSWORD));
+        verifyNoSslProperties(properties);
+    }
+
+    @Test
+    public void setAuthKafkaProperties_withSaslSsl_setsSaslSslProperties() throws Exception {
+        Map<String, String> testConfigOptions = createTestConfigOptions(KafkaUtils.AuthType.SASL_SSL_PLAIN.toString());
+        Properties properties = getKafkaProperties(testConfigOptions);
+
+        verifyCommonSaslProperties(properties, SASL_SSL, PLAIN, formatJaasConfig(false, TEST_USERNAME, TEST_PASSWORD));
+
+        assertNotNull(properties.get(SSL_TRUSTSTORE_LOCATION));
+        assertNotNull(properties.get(SSL_TRUSTSTORE_PASSWORD));
+        assertEquals(TEST_TRUSTSTORE_PASSWORD, properties.get(SSL_TRUSTSTORE_PASSWORD));
+    }
+
+    @Test
+    public void setAuthKafkaProperties_withSaslSslWithoutCertificates_setsSaslSslProperties() throws Exception {
+        Map<String, String> testConfigOptions = createTestConfigOptions(KafkaUtils.AuthType.SASL_SSL_PLAIN.toString());
+        testConfigOptions.remove(KafkaConstants.CERTIFICATES_S3_REFERENCE); // Remove S3 reference
+
+        Properties properties = getKafkaProperties(testConfigOptions);
+
+        verifyCommonSaslProperties(properties, SASL_SSL, PLAIN, formatJaasConfig(false, TEST_USERNAME, TEST_PASSWORD));
+        verifyNoSslProperties(properties);
+    }
+
+    @Test
+    public void setAuthKafkaProperties_withSaslSslEmptyCertificates_setsSaslSslProperties() throws Exception {
+        Map<String, String> testConfigOptions = createTestConfigOptions(KafkaUtils.AuthType.SASL_SSL_PLAIN.toString());
+        testConfigOptions.put(KafkaConstants.CERTIFICATES_S3_REFERENCE, ""); // Empty S3 reference
+
+        Properties properties = getKafkaProperties(testConfigOptions);
+
+        verifyCommonSaslProperties(properties, SASL_SSL, PLAIN, formatJaasConfig(false, TEST_USERNAME, TEST_PASSWORD));
+        verifyNoSslProperties(properties);
+    }
+
+    @Test
+    public void setAuthKafkaProperties_withSaslSslNullCertificates_setsSaslSslProperties() throws Exception {
+        Map<String, String> testConfigOptions = createTestConfigOptions(KafkaUtils.AuthType.SASL_SSL_PLAIN.toString());
+        testConfigOptions.put(KafkaConstants.CERTIFICATES_S3_REFERENCE, null); // Null S3 reference
+
+        Properties properties = getKafkaProperties(testConfigOptions);
+
+        verifyCommonSaslProperties(properties, SASL_SSL, PLAIN, formatJaasConfig(false, TEST_USERNAME, TEST_PASSWORD));
+        verifyNoSslProperties(properties);
+    }
+
+    @Test
+    public void setAuthKafkaProperties_withDifferentCredentials_setsCorrectProperties() throws Exception {
+        String differentCreds = createCredentialsJson(DIFFERENT_USERNAME, DIFFERENT_PASSWORD);
+        Mockito.when(secretValueResponse.secretString()).thenReturn(differentCreds);
+
+        // Test SCRAM PLAINTEXT
+        Map<String, String> testConfigOptions = createTestConfigOptions(KafkaUtils.AuthType.SASL_PLAINTEXT_SCRAM_SHA512.toString());
+        Properties properties = getKafkaProperties(testConfigOptions);
+        verifyCommonSaslProperties(properties, SASL_PLAINTEXT, SCRAM_SHA_512, formatJaasConfig(true, DIFFERENT_USERNAME, DIFFERENT_PASSWORD));
+
+        // Test SASL PLAIN
+        testConfigOptions.put(KafkaConstants.AUTH_TYPE, KafkaUtils.AuthType.SASL_PLAINTEXT_PLAIN.toString());
+        properties = getKafkaProperties(testConfigOptions);
+        verifyCommonSaslProperties(properties, SASL_PLAINTEXT, PLAIN, formatJaasConfig(false, DIFFERENT_USERNAME, DIFFERENT_PASSWORD));
+
+        // Test SASL SSL
+        testConfigOptions.put(KafkaConstants.AUTH_TYPE, KafkaUtils.AuthType.SASL_SSL_PLAIN.toString());
+        properties = getKafkaProperties(testConfigOptions);
+        verifyCommonSaslProperties(properties, SASL_SSL, PLAIN, formatJaasConfig(false, DIFFERENT_USERNAME, DIFFERENT_PASSWORD));
+        assertEquals(TEST_TRUSTSTORE_PASSWORD, properties.get(SSL_TRUSTSTORE_PASSWORD));
+    }
+
+    private String createCredentialsJson(String username, String password) {
+        return String.format("{\"username\":\"%s\",\"password\":\"%s\",\"keystore_password\":\"%s\",\"truststore_password\":\"%s\",\"ssl_key_password\":\"%s\"}",
+                username, password, KafkaUtilsTest.TEST_KEYSTORE_PASSWORD, KafkaUtilsTest.TEST_TRUSTSTORE_PASSWORD, KafkaUtilsTest.TEST_SSL_KEY_PASSWORD);
+    }
+
+    private String formatJaasConfig(boolean isScram, String username, String password) {
+        return String.format(isScram ? SCRAM_JAAS_TEMPLATE : PLAIN_JAAS_TEMPLATE, username, password);
+    }
+
+    private Map<String, String> createTestConfigOptions(String authType) {
+        Map<String, String> testConfigOptions = new HashMap<>(configOptions);
+        testConfigOptions.put(KafkaConstants.AUTH_TYPE, authType);
+        return testConfigOptions;
+    }
+
+    private void verifyCommonSaslProperties(Properties properties, String expectedProtocol, String expectedMechanism, String expectedJaasConfig) {
+        assertEquals(expectedProtocol, properties.get(SECURITY_PROTOCOL));
+        assertEquals(expectedMechanism, properties.get(SASL_MECHANISM));
+        assertEquals(expectedJaasConfig, properties.get(SASL_JAAS_CONFIG));
+    }
+
+    private void verifyNoSslProperties(Properties properties) {
+        assertNull(properties.get(SSL_TRUSTSTORE_LOCATION));
+        assertNull(properties.get(SSL_TRUSTSTORE_PASSWORD));
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Expanded Kafka connector test coverage: Avro/Protobuf parsing, pagination, offset edge cases, null-records, case-insensitive schema resolution, empty metadata, partition-splitting and multiple exception paths; added many helpers and fixtures.

- Refactor
  - Centralized test constants and helpers; standardized mock/stub setup and test data builders.

- Style
  - Removed redundant imports and unnecessary checked exceptions from test lifecycle methods.

- Chores
  - Updated several dependency versions (build and test environments).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->